### PR TITLE
Insert CSS & JS to avoid document.write blocking

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -14,7 +14,7 @@
           const link = document.createElement('link');
           link.rel = 'stylesheet';
           link.href = '../dist/style.css';
-          document.write(link.outerHTML);
+	  document.getElementsByTagName('head')[0].appendChild(link);
         }
       }());
     </script>
@@ -38,7 +38,7 @@
       (function() {
         const script = document.createElement('script');
         script.src = (process.env.HOT) ? 'http://localhost:3000/dist/bundle.js' : '../dist/bundle.js';
-        document.write(script.outerHTML);
+	document.getElementsByTagName('head')[0].appendChild(script);
       }());
     </script>
     <!-- start Mixpanel --><script type="text/javascript">(function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config reset people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");


### PR DESCRIPTION
The CSS and JS injections happening with document.write gets blocked due to cross-domain loading. Used an alternate method to allow loading.