### PR TITLE
Migrate to official npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css-modules-require-hook": "^2.0.2",
     "del": "^2.2.0",
     "electron-packager": "^7.0.2",
-    "electron-prebuilt": "^1.2.0",
+    "electron": "^1.2.0",
     "electron-rebuild": "^1.1.4",
     "eslint": "^2.10.2",
     "eslint-config-airbnb": "^9.0.1",


### PR DESCRIPTION
electron-prebuilt is a legacy package name that made it difficult for developer to find Electron with npm. electron-prebuild still exists for backward compatibility, but developers are encouraged to migrate. https://github.com/electron-userland/electron-prebuilt/issues/160