### PR TITLE
V0.9.1 branch

### DIFF
--- a/app/js/profiles/ImportProfilePage.js
+++ b/app/js/profiles/ImportProfilePage.js
@@ -47,7 +47,7 @@ class ImportPage extends Component {
             </i></p>
             <div className="highlight">
               <pre>
-                <code>{this.props.addresses[0]}</code> // FIXME: show first unused name 
+                <code>{this.props.addresses[0]}</code>
               </pre>
             </div>
           </div>

--- a/app/js/profiles/ImportProfilePage.js
+++ b/app/js/profiles/ImportProfilePage.js
@@ -8,7 +8,8 @@ import { AccountActions } from '../account/store/account'
 
 function mapStateToProps(state) {
   return {
-    addresses: state.account.identityAccount.addresses
+    addresses: state.account.identityAccount.addresses,
+    nextUnusedAddressIndex: state.account.identityAccount.addressIndex
   }
 }
 
@@ -33,21 +34,20 @@ class ImportPage extends Component {
 
   render() {
     return (
-      <div className="body-inner body-inner-white">
-        <PageHeader title="Import" />
+      <div className="card-list-container profile-content-wrapper">
+        <div>
+          <h5 className="h5-landing">Import Name</h5>
+        </div>
         <div className="container">
-          <div className="col-sm-3">
-          </div>
           <div className="col-sm-6">
-            <h3>Import Identity</h3>
             <p><i>
-              To import an identity into this app,
-              go to the app that owns the identity,
-              then find the export form and enter the transfer code below.
+              To import a name into this wallet,
+              go to the app that owns the name,
+              find the export form and enter the transfer code below.
             </i></p>
             <div className="highlight">
               <pre>
-                <code>{this.props.addresses[this.props.addresses.length-1]}</code>
+                <code>{this.props.addresses[0]}</code> // FIXME: show first unused name 
               </pre>
             </div>
           </div>

--- a/native/macos/Blockstack/Blockstack/Info.plist
+++ b/native/macos/Blockstack/Blockstack/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.9.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>39</string>
+	<string>40</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/macos/build_blockstack_virtualenv.sh
+++ b/native/macos/build_blockstack_virtualenv.sh
@@ -48,7 +48,7 @@ pip install --upgrade git+https://github.com/blockstack/zone-file-py.git@7373961
 
 echo "Installing latest blockstack..."
 
-pip install --upgrade git+https://github.com/blockstack/blockstack-core.git@1a98efe91eca89cb1afe680bf4af7e15a53b2296
+pip install --upgrade git+https://github.com/blockstack/blockstack-core.git@a8d84d5a5b0413eae4f5a6ad27d4a083d61dff51
 
 echo "Blockstack virtual environment created."
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack-portal",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Blockstack Inc <admin@blockstack.com>",
   "description": "The Blockstack browser portal",
   "license": "MPL-2.0",


### PR DESCRIPTION
Includes patched core which modifies the registrar code to keep retrying transactions (except for preregister) instead of giving up after 130 blocks. Also includes a "hidden" import page that we can direct people to to help them issue manual `NAME_TRANSFER` operations via the CLI.