### PR TITLE
Open delete confirm on press enter

### DIFF
--- a/app/js/account/DeleteAccountPage.js
+++ b/app/js/account/DeleteAccountPage.js
@@ -103,7 +103,7 @@ class DeleteAccountPage extends Component {
           <InputGroup
             name="password" label="Password" type="password"
             data={this.state} onChange={this.onValueChange}
-            onReturnKeyPress={this.deleteAccount}
+            onReturnKeyPress={this.openModal}
           />
 
           <div className="container-fluid m-t-40">


### PR DESCRIPTION
Closes: https://github.com/blockstack/blockstack-browser/issues/798

- Did not realize there was a `onReturnKeyPress` prop. 😅 
- Open the modal instead of deleting the account