### PR TITLE
Tool-tip wrapper component create and linter fix

### DIFF
--- a/app/js/components/ToolTip.js
+++ b/app/js/components/ToolTip.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactTooltip from 'react-tooltip'
+
+const ToolTip = (props) => (
+  <ReactTooltip
+    place={props.place}
+    type={props.type}
+    effect={props.effect}
+    id={props.id}
+    className={props.className}
+    offset={props.offset}
+  >
+    {props.children}
+  </ReactTooltip>
+)
+
+ToolTip.propTypes = {
+  place: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  effect: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  className: PropTypes.string.isRequired,
+  offset: PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired
+}
+
+ToolTip.defaultProps = {
+  place: 'bottom',
+  type: 'dark',
+  effect: 'solid',
+  className: 'text-center',
+  offset: {
+    bottom: '20',
+    right: '10'
+  }
+}
+
+export default ToolTip

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { Person } from 'blockstack'
 import Modal from 'react-modal'
-import ReactTooltip from 'react-tooltip'
 import SecondaryNavBar from '../components/SecondaryNavBar'
 import Alert from '../components/Alert'
 import Image from '../components/Image'
@@ -13,6 +12,7 @@ import { IdentityActions } from './store/identity'
 import { AccountActions }  from '../account/store/account'
 import SocialAccountItem from './components/SocialAccountItem'
 import PGPAccountItem from './components/PGPAccountItem'
+import ToolTip from '../components/ToolTip'
 
 import log4js from 'log4js'
 
@@ -224,10 +224,14 @@ class DefaultProfilePage extends Component {
             </button>
           </form>
         </Modal>
-        <ReactTooltip place="top" type="dark" effect="solid" id="domainName" className="text-center">
-          <div>This is your owner address.</div>
-          <div className="text-secondary">You can switch to a more meaningful name by adding an username.</div>
-        </ReactTooltip>
+        <ToolTip id="domainName">
+          <div>
+            <div>This is your owner address.</div>
+            <div className="text-secondary">
+              You can switch to a more meaningful name by adding an username.
+            </div>
+          </div>
+        </ToolTip>
         <div>
           <SecondaryNavBar
             leftButtonTitle="Edit"

--- a/app/js/profiles/ViewProfilePage.js
+++ b/app/js/profiles/ViewProfilePage.js
@@ -3,13 +3,13 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { Person } from 'blockstack'
-import ReactTooltip from 'react-tooltip'
 import SecondaryNavBar from '../components/SecondaryNavBar'
 import SocialAccountItem from './components/SocialAccountItem'
 import PGPAccountItem from './components/PGPAccountItem'
 import Image from '../components/Image'
 import { IdentityActions } from './store/identity'
 import { SearchActions } from './store/search'
+import ToolTip from '../components/ToolTip'
 
 const placeholderImage = "https://s3.amazonaws.com/65m/avatar-placeholder.png"
 
@@ -119,17 +119,18 @@ class ViewProfilePage extends Component {
         <SecondaryNavBar
           leftButtonTitle="Edit"
           leftButtonLink={`/profiles/${domainName}/edit`}
-          rightButtonTitle="More" 
+          rightButtonTitle="More"
           rightButtonLink="/profiles/i/all" />
         }
 
         { person !== null ?
         <div>
-
-          <ReactTooltip place="top" type="dark" effect="solid" id="domainName" className="text-center">
+          <ToolTip id="domainName">
             <div>This is your owner address.</div>
-            <div className="text-secondary">You can switch to a more meaningful name by adding an username.</div>
-          </ReactTooltip>
+            <div className="text-secondary">
+              You can switch to a more meaningful name by adding an username.
+            </div>
+          </ToolTip>
 
           <div className="container-fluid m-t-50">
             <div className="row">


### PR DESCRIPTION
Closes  https://github.com/blockstack/blockstack-browser/issues/794#issuecomment-330358289

- Created a new component called `ToolTip`.  Wrapper around `ReactToolTip` library component.  This is so we don't have to recreate the same component with the same configurations every time ToolTip is used.  The default position will on the bottom as opposed to the top.
- Also fixed linter warnings/error.

Components affected:
1. DefaultProfilePage.js
2. ViewProfilePage.js 

@guylepage3 I couldn't test it on `ViewProfilePage` because I didn't have an account name.  Can you confirm the positioning is correct?

![screenshot of google chrome 9-18-17 6-31-06 pm](https://user-images.githubusercontent.com/8473884/30570295-534aae66-9cae-11e7-987f-d8175a702d8a.png)

