### PR TITLE
Edit profile should check storageConnected rather than dropboxAccessToken

### DIFF
--- a/app/js/profiles/EditProfilePage.js
+++ b/app/js/profiles/EditProfilePage.js
@@ -140,7 +140,7 @@ class EditProfilePage extends Component {
     const verifications = identity.verifications
 
     this.props.updateProfile(this.props.routeParams.index, newProfile, verifications)
-    if (this.hasUsername() && this.props.api.dropboxAccessToken !== null) {
+    if (this.hasUsername() && this.props.api.storageConnected) {
       logger.trace('saveProfile: Preparing to upload profile')
       const ownerAddress = this.props.localIdentities[profileIndex].ownerAddress
       const addressIndex = findAddressIndex(ownerAddress, this.props.identityAddresses)
@@ -297,7 +297,7 @@ class EditProfilePage extends Component {
       }
     } else if (event.target.name === 'proofUrl') {
 
-      if (this.hasUsername() && this.props.api.dropboxAccessToken !== null) {
+      if (this.hasUsername() && this.props.api.storageConnected) {
         this.refreshProofs()
       }
 


### PR DESCRIPTION
This led to the bug in #901 -- the profile skips saves when connected via gaia hub instead of dropbox.