### PR TITLE
Fix backup account wording inconsistency in settings tab. Issue: #929

### DIFF
--- a/app/js/account/BackupAccountPage.js
+++ b/app/js/account/BackupAccountPage.js
@@ -1,3 +1,4 @@
+
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
@@ -62,11 +63,11 @@ class BackupAccountPage extends Component {
 
     const password = this.state.password
     const dataBuffer = new Buffer(this.props.encryptedBackupPhrase, 'hex')
-    logger.debug('Trying to decrypt backup phrase...')
+    logger.debug('Trying to decrypt recovery phrase...')
     decrypt(dataBuffer, password)
     .then((plaintextBuffer) => {
-      logger.debug('Backup phrase successfully decrypted')
-      this.updateAlert('success', 'Backup phrase decrypted')
+      logger.debug('Recovery phrase successfully decrypted')
+      this.updateAlert('success', 'Recovery phrase decrypted')
       this.props.displayedRecoveryCode()
       this.setState({
         decryptedBackupPhrase: plaintextBuffer.toString()
@@ -104,14 +105,14 @@ class BackupAccountPage extends Component {
               <div className="col">
                 <p>
                   <i>
-                    Write down the backup phrase below and keep it safe.
+                    Write down the recovery phrase below and keep it safe.
                     Anyone who has it will be able to regain access to your account.
                   </i>
                 </p>
 
                 <div className="card">
                   <div className="card-header">
-                    Backup Phrase
+                    Recovery Phrase
                   </div>
                   <div className="card-block backup-phrase-container">
                     <p className="card-text">
@@ -127,7 +128,7 @@ class BackupAccountPage extends Component {
             <div className="row">
               <div className="col">
                 <p className="container-fluid">
-                  <i>Enter your password to view your backup phrase and backup your account.</i>
+                  <i>Enter your password to view your recovery phrase and backup your account.</i>
                 </p>
                 <InputGroup
                   name="password" label="Password" type="password"
@@ -136,7 +137,7 @@ class BackupAccountPage extends Component {
                 />
                 <div className="container-fluid m-t-40">
                   <button className="btn btn-primary btn-block" onClick={this.decryptBackupPhrase}>
-                    Decrypt Backup Phrase
+                    Decrypt Recovery Phrase
                   </button>
                 </div>
               </div>

--- a/app/js/account/BackupAccountPage.js
+++ b/app/js/account/BackupAccountPage.js
@@ -1,4 +1,3 @@
-
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'

--- a/app/js/account/ChangePasswordPage.js
+++ b/app/js/account/ChangePasswordPage.js
@@ -63,17 +63,17 @@ class ChangePasswordPage extends Component {
     const newPassword = this.state.newPassword
     const newPassword2 = this.state.newPassword2
     const dataBuffer = new Buffer(this.props.encryptedBackupPhrase, 'hex')
-    logger.debug('Trying to decrypt backup phrase...')
+    logger.debug('Trying to decrypt recovery phrase...')
     decrypt(dataBuffer, currentPassword)
     .then((plaintextBuffer) => {
-      logger.debug('Backup phrase successfully decrypted')
+      logger.debug('Recovery phrase successfully decrypted')
       if (newPassword.length < 8) {
         this.updateAlert('danger', 'New password must be at least 8 characters')
       } else {
         if (newPassword !== newPassword2) {
           this.updateAlert('danger', 'New passwords must match')
         } else {
-          logger.debug('Trying to re-encrypt backup phrase with new password...')
+          logger.debug('Trying to re-encrypt recovery phrase with new password...')
           encrypt(plaintextBuffer, newPassword)
           .then((ciphertextBuffer) => {
             this.props.updateBackupPhrase(ciphertextBuffer.toString('hex'))

--- a/app/js/account/DeleteAccountPage.js
+++ b/app/js/account/DeleteAccountPage.js
@@ -69,7 +69,7 @@ class DeleteAccountPage extends Component {
     logger.trace('deleteAccount')
     const password = this.state.password
     const dataBuffer = new Buffer(this.props.encryptedBackupPhrase, 'hex')
-    logger.debug('Trying to decrypt backup phrase...')
+    logger.debug('Trying to decrypt recovery phrase...')
     decrypt(dataBuffer, password)
     .then(() => {
       this.setState({ isOpen: true })

--- a/app/js/account/components/DeleteAccountModal.js
+++ b/app/js/account/components/DeleteAccountModal.js
@@ -15,7 +15,7 @@ const DeleteAccountModal = (props) => (
     <div className="modal-body">
       <p>
         This will remove your account information from Blockstack.
-        Please save your backup phrase and password
+        Please save your recovery phrase and password
         if you want to retrieve your account in the future.
       </p>
     </div>


### PR DESCRIPTION
Closes issue #929

Problem: 

- The "backup account" view in the settings panel has different wording than the rest of the app.

Solution:

- Solution: All instances of "backup phrase" were changed to "recovery phrase".

Please let me know if there are any issues with this PR. Happy to contribute. 