### PR TITLE
Light-weight multi-reader storage

### DIFF
--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -10,6 +10,7 @@ import { AccountActions }  from '../account/store/account'
 import SecondaryNavBar from '../components/SecondaryNavBar'
 import SocialAccountItem from './components/SocialAccountItem'
 import PGPAccountItem from './components/PGPAccountItem'
+import CustomAccountItem from './components/CustomAccountItem'
 import ProfileCompletion from './components/ProfileCompletion'
 import InputGroup from '../components/InputGroup'
 import ToolTip from '../components/ToolTip'
@@ -44,6 +45,7 @@ const accountTypes = [
 ]
 
 const hiddenAccountTypes = [
+  'custom',
   'linkedIn',
   'instagram'
 ]
@@ -193,7 +195,7 @@ class DefaultProfilePage extends Component {
     }
   }
 
-  onAccountClick = (service) => {
+  onAccountClick = (service, identifier) => {
     if (this.state.accountEditIsOpen) {
       this.setState({
         accountEditIsOpen: false,
@@ -204,7 +206,9 @@ class DefaultProfilePage extends Component {
 
       if (this.state.profile.account) {
         this.state.profile.account.forEach((account) => {
-          if (account.service === service) {
+          if (account.service === 'custom' && account.identifier === identifier) {
+            editingAccount = account
+          } else if (account.service === service && service !== 'custom') {
             editingAccount = account
           }
         })
@@ -297,7 +301,7 @@ class DefaultProfilePage extends Component {
       })
 
       if (!hasAccount && identifier.length > 0) {
-        const newAccount = this.createNewAccount(service, identifier, proofUrl)
+        const newAccount = this.createNewAccount({ service, identifier, proofUrl })
         if (this.shouldAutoGenerateProofUrl(service)) {
           newAccount.proofUrl = this.generateProofUrl(service, identifier)
         }
@@ -315,7 +319,7 @@ class DefaultProfilePage extends Component {
     this.closeSocialAccountModal()
   }
 
-  onAccountDoneButtonClick = (service, identifier) => {
+  onAccountDoneButtonClick = (service, identifier, value) => {
     const profile = this.state.profile
 
     if (!profile.hasOwnProperty('account')) {
@@ -325,7 +329,13 @@ class DefaultProfilePage extends Component {
     if (profile.hasOwnProperty('account')) {
       let hasAccount = false
       profile.account.forEach(account => {
-        if (account.service === service) {
+        if (service === 'custom' && account.identifier === identifier) {
+          hasAccount = true
+          account.value = value
+          this.setState({ profile })
+          this.saveProfile(profile)
+          this.refreshProofs()
+        } else if (account.service === service && service !== 'custom') {
           hasAccount = true
           account.identifier = identifier
           this.setState({ profile })
@@ -335,7 +345,7 @@ class DefaultProfilePage extends Component {
       })
 
       if (!hasAccount && identifier.length > 0) {
-        const newAccount = this.createNewAccount(service, identifier, '')
+        const newAccount = this.createNewAccount({ service, identifier, value, proofURL: '' })
         profile.account.push(newAccount)
         this.setState({ profile })
         this.saveProfile(profile)
@@ -348,6 +358,10 @@ class DefaultProfilePage extends Component {
     }
 
     this.closeAccountModal()
+  }
+
+  onDeleteClick = (index) => {
+    this.removeAccountAtIndex(index)
   }
 
   onMoreAccountsClick = () => {
@@ -488,12 +502,13 @@ class DefaultProfilePage extends Component {
     return this.props.nextUnusedAddressIndex + 1 <= this.props.identityAddresses.length
   }
 
-  createNewAccount(service, identifier, proofUrl) {
+  createNewAccount({ service, identifier, value, proofUrl }) {
     return {
       '@type': 'Account',
       placeholder: false,
       service,
       identifier,
+      value,
       proofType: 'http',
       proofUrl
     }
@@ -507,6 +522,18 @@ class DefaultProfilePage extends Component {
       identifier: '',
       proofType: '',
       proofURL: ''
+    }
+  }
+
+  removeAccountAtIndex = (index) => {
+    const profile = this.state.profile
+    const accounts = profile.account
+
+    if (accounts) {
+      accounts.splice(index, 1)
+      this.setState({ profile })
+      this.saveProfile(profile)
+      this.refreshProofs()
     }
   }
 
@@ -547,23 +574,18 @@ class DefaultProfilePage extends Component {
     const placeholders = []
     let hiddenAccounts = hiddenAccountTypes
 
+    let profileAccounts = []
+
     if (this.state.profile.hasOwnProperty('account')) {
-      accountTypes.forEach((accountType) => {
-        let hasAccount = false
-        this.state.profile.account.forEach((account) => {
-          if (account.service === accountType) {
-            hasAccount = true
-            account.placeholder = false
-            filledAccounts.push(account)
-          }
-        })
+      profileAccounts = this.state.profile.account
+    }
 
-        const hideAccount = (hiddenAccounts.indexOf(accountType) >= 0)
+    profileAccounts.forEach((account) => {
+      account.placeholder = false
+      filledAccounts.push(account)
+    })
 
-        if (hasAccount && hideAccount) {
-          hiddenAccounts = hiddenAccounts.filter(hiddenAccount => hiddenAccount !== accountType)
-        }
-
+<<<<<<< HEAD
         if (!hasAccount) {
           if (hideAccount) {
             if (this.state.showHiddenPlaceholders) {
@@ -578,13 +600,37 @@ class DefaultProfilePage extends Component {
       accountTypes.forEach((accountType) => {
         const hideAccount = (hiddenAccounts.indexOf(accountType) >= 0)
         if (hideAccount) {
+=======
+    accountTypes.forEach((accountType) => {
+      let hasAccount = false
+      profileAccounts.forEach((account) => {
+        if (account.service === accountType) {
+          hasAccount = true
+          // account.placeholder = false
+          // filledAccounts.push(account)
+        }
+      })
+
+      const hideAccount = (hiddenAccounts.indexOf(accountType) >= 0)
+
+      if (hasAccount && hideAccount) {
+        hiddenAccounts = hiddenAccounts.filter(hiddenAccount => hiddenAccount !== accountType)
+      }
+
+      if (!hasAccount) {
+        if (hideAccount) { 
+>>>>>>> Light-weight multi-reader storage via custom profile accounts. Improved account delete UX.
           if (this.state.showHiddenPlaceholders) {
             placeholders.push(this.createPlaceholderAccount(accountType))
           }
         } else {
           placeholders.push(this.createPlaceholderAccount(accountType))
         }
-      })
+      }
+    })
+
+    if (this.state.showHiddenPlaceholders) {
+      placeholders.push(this.createPlaceholderAccount('custom'))
     }
 
     // const accounts = person.profile().account || []
@@ -663,6 +709,7 @@ class DefaultProfilePage extends Component {
                         ownerAddress={ownerAddress}
                         service={this.state.editingAccount.service}
                         identifier={this.state.editingAccount.identifier}
+                        value={this.state.editingAccount.value}
                         onDoneButtonClick={this.onAccountDoneButtonClick}
                       />
                     </div>
@@ -687,6 +734,7 @@ class DefaultProfilePage extends Component {
               ownerAddress={ownerAddress}
               service={this.state.editingAccount.service}
               identifier={this.state.editingAccount.identifier}
+              value={this.state.editingAccount.value}
               onDoneButtonClick={this.onAccountDoneButtonClick}
             />
           </Modal>
@@ -942,7 +990,7 @@ class DefaultProfilePage extends Component {
                   <div className="col">
                     <div className="profile-accounts">
                       <ul>
-                        {accounts.map((account) => {
+                        {accounts.map((account, index) => {
                           let verified = false
                           let pending = false
                           if (verifications.length > 0) {
@@ -964,19 +1012,36 @@ class DefaultProfilePage extends Component {
                             return (
                               <PGPAccountItem
                                 key={`${account.service}-${account.identifier}`}
+                                index={index}
                                 editing={this.state.editMode}
                                 service={account.service}
                                 identifier={account.identifier}
                                 contentUrl={account.contentUrl}
                                 placeholder={account.placeholder}
                                 onClick={this.onAccountClick}
+                                onDeleteClick={this.onDeleteClick}
                                 listItem
+                              />
+                            )
+                          } else if (account.service === 'custom') {
+                            return (
+                              <CustomAccountItem
+                                key={`${account.service}-${index}`}
+                                index={index}
+                                editing={this.state.editMode}
+                                service={account.service}
+                                identifier={account.identifier}
+                                value={account.value}
+                                placeholder={account.placeholder}
+                                onClick={this.onAccountClick}
+                                onDeleteClick={this.onDeleteClick}
                               />
                             )
                           } else {
                             return (
                               <SocialAccountItem
                                 key={`${account.service}-${account.identifier}`}
+                                index={index}
                                 editing={this.state.editMode}
                                 service={account.service}
                                 identifier={account.identifier}
@@ -986,6 +1051,7 @@ class DefaultProfilePage extends Component {
                                 placeholder={account.placeholder}
                                 pending={pending}
                                 onClick={this.onSocialAccountClick}
+                                onDeleteClick={this.onDeleteClick}
                               />
                             )
                           }

--- a/app/js/profiles/components/CustomAccountItem.js
+++ b/app/js/profiles/components/CustomAccountItem.js
@@ -1,0 +1,86 @@
+import React, { Component, PropTypes } from 'react'
+import { Link } from 'react-router'
+import { connect } from 'react-redux'
+import Modal from 'react-modal'
+import ReactTooltip from 'react-tooltip'
+
+import { openInNewTab, getWebAccountTypes } from '../../utils'
+
+function mapStateToProps(state) {
+  return {
+    api: state.settings.api
+  }
+}
+
+class CustomAccountItem extends Component {
+  static propTypes = {
+    editing: PropTypes.bool.isRequired,
+    index: PropTypes.number.isRequired,
+    service: PropTypes.string.isRequired,
+    identifier: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    api: PropTypes.object.isRequired,
+    placeholder: PropTypes.bool,
+    onClick: PropTypes.func,
+    onDeleteClick: PropTypes.func
+  }
+
+  constructor(props) {
+    super(props)
+  }
+
+  getIdentifier = () => {
+    let identifier = this.props.identifier
+    if (identifier.length >= 40) {
+      identifier = identifier.slice(0, 40) + '...'
+    }
+    return identifier
+  }
+
+  onClick = (e) => {
+    this.props.onClick(this.props.service, this.props.identifier)
+  }
+
+  onDeleteClick = (e) => {
+    e.stopPropagation()
+    this.props.onDeleteClick(this.props.index)
+  }
+
+  render() {
+    const placeholderClass = this.props.placeholder ? "placeholder" : ""
+    return (
+      <li className={`clickable ${placeholderClass}`} onClick={this.onClick}>  
+
+        <span className="app-account-icon">
+          <i className={`fa fa-fw fa-link fa-lg`} />
+        </span>
+
+        {!this.props.placeholder && (
+          <span className="app-account-identifier">
+            {this.props.service === 'custom' ? this.props.value : this.getIdentifier()}
+          </span>
+        )}
+
+        {!this.props.placeholder && (
+          <span className="app-account-service font-weight-normal">
+            {this.props.service === 'custom' ? this.getIdentifier() : this.props.service}
+          </span>
+        )}
+
+        {(!this.props.placeholder && this.props.editing) && (
+          <span className="" onClick={this.onDeleteClick}>
+            <i className="fa fa-fw fa-trash" />
+          </span>
+        )}
+
+        {this.props.placeholder && (
+          <span className="app-account-service font-weight-normal">
+            Add a custom account
+          </span>
+        )}
+      </li>
+    )
+  }
+}
+
+export default connect(mapStateToProps, null)(CustomAccountItem)

--- a/app/js/profiles/components/EditAccount.js
+++ b/app/js/profiles/components/EditAccount.js
@@ -15,6 +15,7 @@ class EditAccount extends Component {
   static propTypes = {
     service: PropTypes.string,
     identifier: PropTypes.string,
+    value: PropTypes.string,
     api: PropTypes.object.isRequired,
     onDoneButtonClick: PropTypes.func
   }
@@ -23,7 +24,8 @@ class EditAccount extends Component {
     super(props)
 
     this.state = {
-      identifier: props.identifier
+      identifier: props.identifier,
+      value: props.value
     }
   }
 
@@ -48,6 +50,10 @@ class EditAccount extends Component {
   }
 
   getIconClass = () => {
+    if (this.props.service === 'custom') {
+      return 'fa-link'
+    }
+
     const webAccountTypes = getWebAccountTypes(this.props.api)
     let iconClass = ''
     if (webAccountTypes.hasOwnProperty(this.props.service)) {
@@ -71,14 +77,21 @@ class EditAccount extends Component {
     })
   }
 
+  onValueChange = (event) => {
+    let value = event.target.value
+    this.setState({
+      value: value
+    })
+  }
+
   getIdentifierType = (service) => {
     if(service === 'bitcoin' || service === 'ethereum') {
       return "address"
-    }
-    else if (service === 'pgp' || service === 'ssh') {
+    } else if (service === 'pgp' || service === 'ssh' || service === 'custom') {
       return "key"
-    }
-    else {
+    } else if ( service === 'custom') {
+      return "key"
+    } else {
       return "account"
     }
   }
@@ -95,6 +108,13 @@ class EditAccount extends Component {
       return (
         <span className="app-account-service font-weight-bold">
           Add your {service.toUpperCase()} key
+        </span>
+      )
+    }
+    else if (service === 'custom') {
+      return (
+        <span className="app-account-service font-weight-bold">
+          Add your custom account
         </span>
       )
     }
@@ -115,9 +135,10 @@ class EditAccount extends Component {
     const webAccountTypes = getWebAccountTypes(this.props.api)
     const verifiedClass = this.props.verified ? "verified" : (this.state.collapsed ? "pending" : "")
     let webAccountType = webAccountTypes[this.props.service]
+    const customService = this.props.service === 'custom'
+    const identifierType = this.capitalize(this.getIdentifierType(this.props.service))
 
-    if (webAccountType) {
-      let accountServiceName = webAccountType.label
+    if (webAccountType || customService) {
         return (
           <div>
             <div className={`profile-account ${verifiedClass}`} 
@@ -130,19 +151,34 @@ class EditAccount extends Component {
               <div>
                 <InputGroup 
                   key="input-group-identifier"
+                  label={identifierType}
                   name="identifier" 
-                  placeholder={this.capitalize(this.getIdentifierType(this.props.service))}
+                  placeholder={identifierType}
                   data={this.state}
                   stopClickPropagation={true} 
                   onChange={this.onIdentifierChange} 
                 />
-              
               </div>
+
+              {customService &&
+                <div>
+                  <InputGroup 
+                    key="input-group-value"
+                    label="Value"
+                    name="value" 
+                    placeholder="Value"
+                    data={this.state}
+                    stopClickPropagation={true} 
+                    onChange={this.onValueChange} 
+                  />
+                </div>
+              }
+
             </div>
             <button 
               className="btn btn-verify btn-block m-t-15" 
               onClick={e => this.props.onDoneButtonClick(this.props.service, 
-                this.state.identifier)}>
+                this.state.identifier, this.state.value)}>
               Save
             </button>
           </div>

--- a/app/js/profiles/components/PGPAccountItem.js
+++ b/app/js/profiles/components/PGPAccountItem.js
@@ -28,7 +28,8 @@ class PGPAccountItem extends Component {
     contentUrl: PropTypes.string,
     loadPGPPublicKey: PropTypes.func.isRequired,
     pgpPublicKeys: PropTypes.object,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    onDeleteClick: PropTypes.func
   }
 
   constructor(props) {
@@ -102,6 +103,11 @@ class PGPAccountItem extends Component {
     this.props.onClick(this.props.service)
   }
 
+  onDeleteClick = (e) => {
+    e.stopPropagation()
+    this.props.onDeleteClick(this.props.index)
+  }
+
   render() {
     const identifier = this.props.identifier
     const webAccountTypes = getWebAccountTypes(this.props.api)
@@ -173,15 +179,15 @@ class PGPAccountItem extends Component {
             </span>
           )}
 
-          {(!this.props.placeholder && this.props.editing) && (
-            <span className="">
-              <i className="fa fa-fw fa-pencil" />
+          {!this.props.placeholder && (
+            <span className="app-account-service font-weight-normal">
+              {webAccountTypes[this.props.service].label}
             </span>
           )}
 
-          { !this.props.placeholder && (
-            <span className="app-account-service font-weight-normal">
-              {webAccountTypes[this.props.service].label}
+          {(!this.props.placeholder && this.props.editing) && (
+            <span className="" onClick={this.onDeleteClick}>
+              <i className="fa fa-fw fa-trash" />
             </span>
           )}
 

--- a/app/js/profiles/components/SocialAccountItem.js
+++ b/app/js/profiles/components/SocialAccountItem.js
@@ -23,7 +23,8 @@ class SocialAccountItem extends Component {
     pending: PropTypes.bool,
     api: PropTypes.object.isRequired,
     placeholder: PropTypes.bool,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    onDeleteClick: PropTypes.func
   }
 
   constructor(props) {
@@ -94,6 +95,11 @@ class SocialAccountItem extends Component {
     this.props.onClick(this.props.service)
   }
 
+  onDeleteClick = (e) => {
+    e.stopPropagation()
+    this.props.onDeleteClick(this.props.index)
+  }
+
   onVerifiedCheckmarkClick = (e) => {
     e.preventDefault()
     e.stopPropagation()
@@ -134,15 +140,15 @@ class SocialAccountItem extends Component {
               </span>
             )}
 
-            {(!this.props.placeholder && this.props.editing) && (
-              <span className="">
-                <i className="fa fa-fw fa-pencil" />
-              </span>
-            )}
-
             {!this.props.placeholder && (
               <span className="app-account-service font-weight-normal">
                 {`@${accountServiceName}`}
+              </span>
+            )}
+
+            {(!this.props.placeholder && this.props.editing) && (
+              <span className="" onClick={this.onDeleteClick}>
+                <i className="fa fa-fw fa-trash" />
               </span>
             )}
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "bigi": "^1.4.2",
     "bip39": "^2.2.0",
     "bitcoinjs-lib": "^3.2.0",
-    "blockstack": "0.13.5",
+    "blockstack": "0.13.7",
     "body-parser": "^1.16.1",
     "bootstrap": "^4.0.0-beta",
     "browser-stdout": "^1.3.0",


### PR DESCRIPTION
Adds ability to add custom key/values to the user profile. This enables a very light-weight form of multi-reader storage. For now custom key/values will need to be manually entered. An update to blockstack.js is planned to give apps the ability to programmatically add/edit key values with the user's permission. Also included in this PR is the ability to delete accounts.

![image](https://user-images.githubusercontent.com/29081231/33299333-17a7bc22-d3b9-11e7-8635-cea9244f6d0c.png)

Custom account in profile:
![image](https://user-images.githubusercontent.com/29081231/33299349-27d042a4-d3b9-11e7-94c9-1b9f730bd295.png)

In edit mode, you can now click on the trash can to delete an account
![image](https://user-images.githubusercontent.com/29081231/33299525-060625fc-d3ba-11e7-9300-1514b59c3d9a.png)
