### PR TITLE
Tool-Tip fix for profiles

### DIFF
--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -722,7 +722,13 @@ class DefaultProfilePage extends Component {
         {socialAccountEdit()}
         {accountEdit()}
 
-        <ToolTip id="ownerAddress">
+        <ToolTip
+          id="ownerAddress"
+          offset={{
+            bottom: '20',
+            right: '120'
+          }}
+        >
           <div>
             <div>This is your identity address.</div>
           </div>


### PR DESCRIPTION
Fixes https://github.com/blockstack/blockstack-browser/issues/906

Previous Tooltip
<img width="336" alt="screenshot of google chrome 12-13-17 12-21-09 am" src="https://user-images.githubusercontent.com/8473884/33923032-a9be481c-df9c-11e7-9884-71d7a3e3138b.png">

Now:
<img width="196" alt="screenshot of google chrome 12-13-17 12-21-00 am" src="https://user-images.githubusercontent.com/8473884/33923025-a445b3ca-df9c-11e7-8bda-2d862e3285c2.png">

As opposed to hovering it over where the mouse is, I think having it centered looks better.  Whenever you use the tooltip and you see thats its not placed properly you will need to utilize the built in `offset` prop. 


