### PR TITLE
Issue #923: Clarifying default storage copy during initial setup.

### DIFF
--- a/app/js/welcome/components/ConnectStorageView.js
+++ b/app/js/welcome/components/ConnectStorageView.js
@@ -29,7 +29,7 @@ class ConnectStorageView extends Component {
         {!showAdvanced ?
           <div>
             <h3 className="modal-heading m-t-15 p-b-20">
-              App data is stored in the storage provider of your choice
+              Your data is stored on the storage provider of your choice.
             </h3>
             <img
               role="presentation"
@@ -45,15 +45,20 @@ class ConnectStorageView extends Component {
                 Use default storage
               </button>
               <a href="#" className="modal-body" onClick={this.toggleView}>
-                Choose another storage provider
+                Preview alternative storage
               </a>
             </div>
           </div>
         :
           <div className="storage-page">
             <h3 className="modal-heading m-t-15 p-b-20">
-              Choose your storage provider
+              Alternative Storage Preview
             </h3>
+            <p className="container-fluid">
+              You control your data. 
+              All data is encrypted and stored on the storage provider you choose. 
+              Our default storage, Gaia, can be run on your own cloud storage instance.
+            </p>
             <div className="m-t-40">
               <button
                 className="btn btn-primary btn-block m-b-20"


### PR DESCRIPTION
Just copy changes to hopefully address #923

After initial setup, while browsing the storage settings, I realized I didn't have a very good understanding of what 'default storage' meant, or what my storage options are. A quick google search brought up issue #923, so in researching the ticket thought I'd make this pull request.

I changed the link copy of the first storage screen to read 'Preview alternative storage' to better set user expectations that alternative storage is not yet available. The second storage screen title is 'Alternative Storage Preview', and includes a description that attempts to reassure and explain that the default storage system, Gaia, is both private and configurable.