### PR TITLE
Fix apps key doesn't populate issue #1194

### DIFF
--- a/app/js/account/StorageProvidersPage.js
+++ b/app/js/account/StorageProvidersPage.js
@@ -92,7 +92,7 @@ class StorageProvidersPage extends Component {
         const profileSigningKeypair = this.props.identityKeypairs[identityIndex]
         const profile = identity.profile
         setCoreStorageConfig(newApi, identityIndex, identityAddress,
-          profile, profileSigningKeypair)
+          profile, profileSigningKeypair, identity)
         .then((indexUrl) => {
           logger.debug(`componentDidMount: indexUrl: ${indexUrl}`)
           // TODO add index URL to token file

--- a/app/js/auth/components/AuthModal.js
+++ b/app/js/auth/components/AuthModal.js
@@ -221,12 +221,15 @@ class AuthModal extends Component {
         if (storageConnected) {
           getAppBucketUrl('https://hub.blockstack.org', appPrivateKey)
           .then((appBucketUrl) => {
-            const identityAddress = identity.ownerAddress
+            logger.debug(`componentWillReceiveProps: appBucketUrl ${appBucketUrl}`)
+            apps[appDomain] = appBucketUrl
+            logger.debug(`componentWillReceiveProps: new apps array ${JSON.stringify(apps)}`)
+            profile.apps = apps
             const signedProfileTokenData = signProfileForUpload(profile,
             nextProps.identityKeypairs[identityIndex])
-            apps[appDomain] = appBucketUrl
-            profile.apps = apps
-            return uploadProfile(this.props.api, identityIndex, identityAddress,
+            logger.debug('componentWillReceiveProps: uploading updated profile with new apps array')
+            return uploadProfile(this.props.api, identity,
+              nextProps.identityKeypairs[identityIndex],
               signedProfileTokenData)
           })
           .then(() => {

--- a/app/js/auth/components/AuthModal.js
+++ b/app/js/auth/components/AuthModal.js
@@ -383,7 +383,7 @@ class AuthModal extends Component {
           if (requestingStoreWrite && needsCoreStorage) {
             logger.trace('login(): Calling setCoreStorageConfig()...')
             setCoreStorageConfig(this.props.api, identityIndex, identity.ownerAddress,
-            identity.profile, profileSigningKeypair)
+            identity.profile, profileSigningKeypair, identity)
             .then(() => {
               logger.trace('login(): Core storage successfully configured.')
               logger.trace('login(): Calling getCoreSessionToken()...')

--- a/app/js/utils/api-utils.js
+++ b/app/js/utils/api-utils.js
@@ -142,7 +142,7 @@ function profileInsertStorageRoutingInfo(profile, driverName, indexUrl) {
  */
 export function setCoreStorageConfig(api,
   identityIndex = null, identityAddress = null, profile = null,
-  profileSigningKeypair = null) {
+  profileSigningKeypair = null, identity = null) {
   if (isCoreEndpointDisabled()) {
     return new Promise((resolve) => {
       resolve('OK')
@@ -206,7 +206,7 @@ export function setCoreStorageConfig(api,
               driverName, indexUrl)
             const data = signProfileForUpload(profile, profileSigningKeypair)
             logger.debug('setCoreStorageConfig: uploading profile...')
-            return uploadProfile(api, identityIndex, identityAddress, data)
+            return uploadProfile(api, identity, profileSigningKeypair, data)
             .then((result) => {
               logger.debug('setCoreStorageConfig: saved index url')
               // saved!


### PR DESCRIPTION
This pull requests fixes 3 problems that were causing the apps keys not to populate to the user's profile.json file when an app requested multi-player storage.

1. the signed profile token data was generated before the new apps array was generated
2. the uploadProfile function was being passed the identity index instead of the identity object
3. the uploadProfile function was being passed the identity address instead of the signing key

While looking into this issue, I also discovered that the `setCoreStorageConfig` function has not been updated to use the new signature of `updateProfile` that changed during the fixes for address generation. We're not going to be supporting core storage going forward so suggest we remove it: #1195.