### PR TITLE
Remove email scope whitelist

### DIFF
--- a/app/js/auth/components/AuthModal.js
+++ b/app/js/auth/components/AuthModal.js
@@ -24,18 +24,6 @@ import { signProfileForUpload } from '../../utils'
 
 const logger = log4js.getLogger('auth/components/AuthModal.js')
 
-const APP_EMAIL_SCOPE_WHITELIST = [
-  'https://staging.blockstack.clients.barefootcoders.com',
-  'https://blockstack.com',
-  'http://localhost:3000',
-  'http://localhost:3001',
-  'http://localhost:3002',
-  'http://localhost:3003',
-  'http://localhost:4000',
-  'http://localhost:5000',
-  'http://localhost:8080'
-]
-
 function mapStateToProps(state) {
   return {
     localIdentities: state.profiles.identity.localIdentities,
@@ -111,15 +99,8 @@ class AuthModal extends Component {
     const authRequest = getAuthRequestFromURL()
     const decodedToken = decodeToken(authRequest)
 
-    const appDomain = decodedToken.payload.domain_name
     const scopes = decodedToken.payload.scopes
-    let invalidScopes = false
-
-    if (scopes.includes('email')
-    && !APP_EMAIL_SCOPE_WHITELIST.includes(appDomain)) {
-      logger.error(`componentWillMount: ${appDomain} not in 'email' scope whitelist`)
-      invalidScopes = true
-    }
+    const invalidScopes = false
 
     if (scopes.includes('email')) {
       this.setState({

--- a/app/js/auth/components/AuthModal.js
+++ b/app/js/auth/components/AuthModal.js
@@ -98,30 +98,16 @@ class AuthModal extends Component {
   componentWillMount() {
     const authRequest = getAuthRequestFromURL()
     const decodedToken = decodeToken(authRequest)
-
-    const scopes = decodedToken.payload.scopes
-    const invalidScopes = false
-
-    if (scopes.includes('email')) {
-      this.setState({
-        scopes: {
-          email: true
-        }
-      })
-    }
-
-    if (scopes.includes('publish_data')) {
-      this.setState({
-        scopes: {
-          publishData: true
-        }
-      })
-    }
+    const { scopes } = decodedToken.payload
 
     this.setState({
       authRequest,
       decodedToken,
-      invalidScopes
+      scopes: {
+        ...this.state.scopes,
+        email: scopes.includes('email'),
+        publishData: scopes.includes('publish_data')
+      }
     })
 
     this.props.verifyAuthRequestAndLoadManifest(authRequest)


### PR DESCRIPTION
We previously restricted access to the `email` scope to apps in our whitelist. 

There is strong interest in the developer community to have access to this functionality so that they can pre-populate email fields with user emails.

This pull request removes the whitelist.

I'm opening it to start a discussion around whether we want to merge this quick and dirty change so that developers can get started or if we want to do additional work: how this is communicated to users, giving users option to opt out, etc.