### PR TITLE
handle other python2.7 paths, upgrades venv pip

### DIFF
--- a/native/macos/build_blockstack_virtualenv.sh
+++ b/native/macos/build_blockstack_virtualenv.sh
@@ -22,7 +22,10 @@ rm -Rfv blockstack-venv
 
 echo "Creating a new virtualenv..."
 
-virtualenv -p /usr/bin/python2.7 blockstack-venv
+virtualenv -p $(which python2.7) blockstack-venv
+
+echo "Updating virtualenv pip to latest version..."                                                                                                                               
+pip install --upgrade pip
 
 echo "Activating virtualenv..."
 


### PR DESCRIPTION
PR handles two small issues I ran into while getting set up:
- having python2.7 at a different path than `/usr/bin/python2.7`
- python2.7 using a version of pip that didn't have the `--only-binary` flag necessary `pip install cryptography --only-binary cryptography`
Hope the generic patch name is ok, since this is small enough to do through github UI. I can also make the PR to the `develop` branch if that's preferred.