### PR TITLE
fix the profile URL used for auth logins without a username.

### DIFF
--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -12,7 +12,7 @@ import {
   authorizationHeaderValue
 } from '../../../utils/index'
 import { DEFAULT_PROFILE,
-  getProfileFromTokens } from '../../../utils/profile-utils'
+  fetchProfileLocations } from '../../../utils/profile-utils'
 import { calculateTrustLevel } from '../../../utils/account-utils'
 import { AccountActions } from '../../../account/store/account'
 import { isWebAppBuild } from '../../../utils/window-utils'
@@ -208,64 +208,6 @@ function createNewProfile(encryptedBackupPhrase: string,
 }
 
 /**
- * Try to fetch and verify a profile from the historic set of default locations,
- * in order of recency. If all of them return 404s, or fail to validate, return null
- */
-function fetchProfileLocations(gaiaUrlBase: string,
-                               ownerAddress: string,
-                               firstAddress: string,
-                               ownerIndex: number) {
-  function recursiveTryFetch(locations) {
-    if (locations.length === 0) {
-      return Promise.resolve(null)
-    }
-    const location = locations[0]
-    return fetch(location)
-      .then(response => {
-        if (response.ok) {
-          return response.json()
-            .then(tokenRecords => getProfileFromTokens(tokenRecords, ownerAddress, false))
-            .then(profile => {
-              logger.debug(`Found valid profile at ${location}`)
-              return profile
-            })
-            .catch(() => {
-              logger.debug(`Failed to verify profile at ${location}... trying others`)
-              return recursiveTryFetch(locations.slice(1))
-            })
-        } else {
-          logger.debug(`Failed to find profile at ${location}... trying others`)
-          return recursiveTryFetch(locations.slice(1))
-        }
-      })
-      .catch(() => {
-        logger.debug(`Error in fetching profile at ${location}... trying others`)
-        return recursiveTryFetch(locations.slice(1))
-      })
-  }
-
-  const urls = []
-  // the new default
-  urls.push(`${gaiaUrlBase}/${ownerAddress}/profile.json`)
-
-  // the 'indexed' URL --
-  //  this is gaia/:firstAddress/:index/profile.json
-  //  however, the index is _not_ equal to the current index.
-  //  indexes were mapped from
-  //    correct: [0, 1, 3, 5, 7, 9...]
-  //  incorrect: [0, 1, 2, 3, 4, 5...]
-
-  if (ownerIndex < 2) {
-    urls.push(`${gaiaUrlBase}/${firstAddress}/${ownerIndex}/profile.json`)
-  } else if (ownerIndex % 2 === 1) {
-    const buggedIndex = 1 + Math.floor(ownerIndex / 2)
-    urls.push(`${gaiaUrlBase}/${firstAddress}/${buggedIndex}/profile.json`)
-  }
-
-  return recursiveTryFetch(urls)
-}
-
-/**
  * Checks each owner address to see if it owns a name, if it owns a name,
  * it resolves the profile and updates the state with the owner address's
  * current name.
@@ -291,7 +233,8 @@ function refreshIdentities(api: {bitcoinAddressLookupUrl: string,
             const gaiaBucketAddress = ownerAddresses[0]
             return fetchProfileLocations('https://gaia.blockstack.org/hub',
                                          address, gaiaBucketAddress, index)
-              .then(profile => {
+              .then(returnObject => {
+                const profile = returnObject.profile
                 if (profile) {
                   const zoneFile = ''
                   dispatch(updateProfile(index, profile, zoneFile))

--- a/app/js/utils/profile-utils.js
+++ b/app/js/utils/profile-utils.js
@@ -3,6 +3,10 @@ import { decodeToken, TokenVerifier } from 'jsontokens'
 
 import ecurve from 'ecurve'
 import { ECPair as ECKeyPair } from 'bitcoinjs-lib'
+import log4js from 'log4js'
+
+const logger = log4js.getLogger('utils/profile-utils.js')
+
 const secp256k1 = ecurve.getCurveByName('secp256k1')
 
 export function verifyToken(token, verifyingKeyOrAddress) {
@@ -98,6 +102,64 @@ export function getProfileFromTokens(tokenRecords, publicKeychain, silentVerify 
   })
 
   return profile
+}
+
+/**
+ * Try to fetch and verify a profile from the historic set of default locations,
+ * in order of recency. If all of them return 404s, or fail to validate, return null
+ */
+export function fetchProfileLocations(gaiaUrlBase: string,
+                                      ownerAddress: string,
+                                      firstAddress: string,
+                                      ownerIndex: number) {
+  function recursiveTryFetch(locations) {
+    if (locations.length === 0) {
+      return Promise.resolve(null)
+    }
+    const location = locations[0]
+    return fetch(location)
+      .then(response => {
+        if (response.ok) {
+          return response.json()
+            .then(tokenRecords => getProfileFromTokens(tokenRecords, ownerAddress, false))
+            .then(profile => {
+              logger.debug(`Found valid profile at ${location}`)
+              return { profile, profileUrl: location }
+            })
+            .catch(() => {
+              logger.debug(`Failed to verify profile at ${location}... trying others`)
+              return recursiveTryFetch(locations.slice(1))
+            })
+        } else {
+          logger.debug(`Failed to find profile at ${location}... trying others`)
+          return recursiveTryFetch(locations.slice(1))
+        }
+      })
+      .catch(() => {
+        logger.debug(`Error in fetching profile at ${location}... trying others`)
+        return recursiveTryFetch(locations.slice(1))
+      })
+  }
+
+  const urls = []
+  // the new default
+  urls.push(`${gaiaUrlBase}/${ownerAddress}/profile.json`)
+
+  // the 'indexed' URL --
+  //  this is gaia/:firstAddress/:index/profile.json
+  //  however, the index is _not_ equal to the current index.
+  //  indexes were mapped from
+  //    correct: [0, 1, 3, 5, 7, 9...]
+  //  incorrect: [0, 1, 2, 3, 4, 5...]
+
+  if (ownerIndex < 2) {
+    urls.push(`${gaiaUrlBase}/${firstAddress}/${ownerIndex}/profile.json`)
+  } else if (ownerIndex % 2 === 1) {
+    const buggedIndex = 1 + Math.floor(ownerIndex / 2)
+    urls.push(`${gaiaUrlBase}/${firstAddress}/${buggedIndex}/profile.json`)
+  }
+
+  return recursiveTryFetch(urls)
 }
 
 export function signProfileForUpload(profile, keypair) {


### PR DESCRIPTION
This changes the AuthModal to use the same profile lookup path as the profile editing components for identities _without_ a user name. This moves the `fetchProfileLocations()` function to `profile-utils`, adding a URL to its return. The AuthModal now calls this to obtain the default profile location.

Test via:

0. Run app `npm run dev` or `npm run dev-webapp` (if you're lazy like me and don't want to start a blockstack API endpoint up).
1. Setting up an identity address with a name in the profile, but _no_ domain/subdomain associated with it.
2. Log into Blockstack Todos, you should see "Your Name's Todos"
3. Log out of Blockstack Todos
4. Log into Blockstack Todos _with_ an identity with an associated domain/subdomain -- you should see the correct information from that profile as well (this is an ad-hoc regression test)

Those above test steps lead me to believe that we want better auth testing in the blockstack-browser test suites sooner rather than later.

This PR addresses issue #1228 

