### PR TITLE
Hotfix for Proxy Bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN /src/blockstack-browser/node_modules/.bin/gulp prod
 
 # Setup script to run browser
 RUN echo '#!/bin/bash' >> /src/blockstack-browser/blockstack-browser
-RUN echo 'node /src/blockstack-browser/native/blockstackProxy.js 8888 /src/blockstack-browser/build' >> /src/blockstack-browser/blockstack-browser
+RUN echo 'node /src/blockstack-browser/native/blockstackProxy.js 8888 /src/blockstack-browser/build 0.0.0.0' >> /src/blockstack-browser/blockstack-browser
 RUN chmod +x /src/blockstack-browser/blockstack-browser
 RUN ln /src/blockstack-browser/blockstack-browser /usr/bin/blockstack-browser

--- a/corsproxy/corsproxy.js
+++ b/corsproxy/corsproxy.js
@@ -1,5 +1,5 @@
 var cors_proxy = require('cors-anywhere');
-var host = '0.0.0.0';
+var host = process.argv[4] || 'localhost';
 var port = 1337;
 cors_proxy.createServer().listen(port, host, function() {
 	console.log('Running CORS Proxy on ' + host + ':' + port);

--- a/native/blockstackProxy.js
+++ b/native/blockstackProxy.js
@@ -9,8 +9,16 @@ var http = require("http"),
     path = require("path"),
     url = require("url"),
     fs = require("fs"),
-    port = process.argv[2] || 8888;
+    port = process.argv[2] || 8888,
+    host = process.argv[4] || 'localhost',
     basePath = process.argv[3] || "./browser";
+
+var checkPrefix = function (prefix, candidate) {
+    // .resolve() removes trailing slashes
+    var absPrefix = path.resolve(prefix) + path.sep;
+    var absCandidate = path.resolve(candidate) + path.sep;
+    return absCandidate.substring(0, absPrefix.length) === absPrefix;
+}
 
 
 /*
@@ -44,11 +52,13 @@ http.createServer(function(request, response) {
   var uri = url.parse(request.url).pathname
     , filename = path.join(basePath, uri);
 
+  var attemptedTraversal = !checkPrefix(basePath, filename)
+
   fs.exists(filename, function(exists) {
 
     /* Always load the single page app index.html
     unless another file exists or this is a directory */
-    if(!exists || fs.statSync(filename).isDirectory()) {
+    if(!exists || attemptedTraversal || fs.statSync(filename).isDirectory()) {
       filename = basePath + "/index.html"
     }
 
@@ -69,8 +79,8 @@ http.createServer(function(request, response) {
       response.end();
     });
   });
-}).listen(parseInt(port, 10));
+}).listen(parseInt(port, 10), host);
 
-console.log("Blockstack Browser proxy server running at: http://localhost:" + port);
+console.log("Blockstack Browser proxy server running at: http://" + host + ":" + port);
 console.log("Browser path: " + basePath);
 console.log("Press Control + C to shutdown");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack-browser",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "author": "Blockstack PBC <admin@blockstack.com>",
   "description": "The Blockstack browser",
   "license": "MPL-2.0",


### PR DESCRIPTION
This hotfix patches the blockstack proxies:

1. to default bind to `localhost`, rather than `0.0.0.0` (it also changes the Dockerfile so that it will set the bind to 0.0.0.0).
2. to check for attempted path traversals and return the `index.html` in those cases.

We should consider a point release for these fixes.