### PR TITLE
Client-side Bitcoin Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Blockstack for macOS contains a Blockstack Core API endpoint & a CORS proxy.
 1. When prompted in your browser, enter the Core API password you selected in part 1.
 
 
-#### Part 3: Running with local regtest
-1. Run browser regtest environment (see [blockstack-core repo](https://github.com/blockstack/blockstack-core/tree/master/integration_tests#running-interactive-tests-with-docker))
-1. Open URL: `localhost:3000/#coreAPIPassword=blockstack_integration_test_api_password&regtest=1`
-
 *Note: npm dev runs a BrowserSync process that watches the assets in `/app`, then builds them and places them in `/build`, and in turn serves them up on port 3000. When changes are made to the original files, they are rebuilt and re-synced to the browser frames you have open.*
 
 ##### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Blockstack for macOS contains a Blockstack Core API endpoint & a CORS proxy.
 1. When prompted in your browser, enter the Core API password you selected in part 1.
 
 
+#### Part 3: Running with local regtest
+1. Run browser regtest environment (see [blockstack-core repo](https://github.com/blockstack/blockstack-core/tree/master/integration_tests#running-interactive-tests-with-docker))
+1. Open URL: `localhost:3000/#coreAPIPassword=blockstack_integration_test_api_password&regtest=1`
+
 *Note: npm dev runs a BrowserSync process that watches the assets in `/app`, then builds them and places them in `/build`, and in turn serves them up on port 3000. When changes are made to the original files, they are rebuilt and re-synced to the browser frames you have open.*
 
 ##### Troubleshooting

--- a/app/js/account/store/account/actions.js
+++ b/app/js/account/store/account/actions.js
@@ -14,6 +14,8 @@ import {
   getInsightUrl
 } from '../../../utils'
 import { isCoreEndpointDisabled } from '../../../utils/window-utils'
+import { transactions, config, network } from 'blockstack'
+
 import roundTo from 'round-to'
 import * as types from './types'
 import log4js from 'log4js'
@@ -255,6 +257,41 @@ function resetCoreWithdrawal() {
   }
 }
 
+function withdrawBitcoinClientSide(
+  regTestMode,
+  paymentKey,
+  recipientAddress,
+  amountBTC
+) {
+  return dispatch => {
+    if (regTestMode) {
+      logger.trace('Using regtest network')
+      config.network = network.defaults.LOCAL_REGTEST
+      // browser regtest environment uses 6270
+      config.network.blockstackAPIUrl = 'http://localhost:6270'
+      recipientAddress = config.network.coerceAddress(recipientAddress)
+    }
+    dispatch(withdrawingCoreBalance(recipientAddress, amountBTC))
+
+    const amountSatoshis = Math.floor(amountBTC * 1e8)
+
+    transactions.makeBitcoinSpend(
+      recipientAddress, paymentKey, amountSatoshis)
+      .then((transactionHex) => {
+        const myNet = config.network
+        logger.trace(`Broadcast btc spend with tx hex: ${transactionHex}`)
+        return myNet.broadcastTransaction(transactionHex)
+      })
+      .then(() => {
+        dispatch(withdrawCoreBalanceSuccess())
+      })
+      .catch((error) => {
+        logger.error('withdrawBitcoinClientSide: error generating and broadcasting', error)
+        dispatch(withdrawCoreBalanceError(error))
+      })
+  }
+}
+
 function withdrawBitcoinFromCoreWallet(
   coreWalletWithdrawUrl,
   recipientAddress,
@@ -440,6 +477,7 @@ const AccountActions = {
   getCoreWalletAddress,
   refreshCoreWalletBalance,
   resetCoreWithdrawal,
+  withdrawBitcoinClientSide,
   withdrawBitcoinFromCoreWallet,
   emailNotifications,
   skipEmailBackup,

--- a/app/js/account/store/account/actions.js
+++ b/app/js/account/store/account/actions.js
@@ -282,12 +282,10 @@ function withdrawBitcoinClientSide(
         logger.trace(`Broadcast btc spend with tx hex: ${transactionHex}`)
         return myNet.broadcastTransaction(transactionHex)
       })
-      .then(() => {
-        dispatch(withdrawCoreBalanceSuccess())
-      })
+      .then(() => dispatch(withdrawCoreBalanceSuccess()))
       .catch((error) => {
         logger.error('withdrawBitcoinClientSide: error generating and broadcasting', error)
-        dispatch(withdrawCoreBalanceError(error))
+        return dispatch(withdrawCoreBalanceError(error))
       })
   }
 }

--- a/app/js/wallet/SendPage.js
+++ b/app/js/wallet/SendPage.js
@@ -7,16 +7,12 @@ import {
   getBitcoinPrivateKeychain,
   getBitcoinAddressNode
 } from '../utils'
-import { AccountActions } from '../account/store/account'
-
 import { isCoreEndpointDisabled, isWindowsBuild } from '../utils/window-utils'
+import { AccountActions } from '../account/store/account'
 
 import Alert from '../components/Alert'
 import InputGroupSecondary from '../components/InputGroupSecondary'
 import Balance from './components/Balance'
-import log4js from 'log4js'
-
-const logger = log4js.getLogger('profiles/store/registration/actions.js')
 
 function mapStateToProps(state) {
   return {
@@ -88,20 +84,20 @@ class SendPage extends Component {
     })
     const password = this.state.password
     const encryptedBackupPhrase = this.props.account.encryptedBackupPhrase
-    const amount = this.state.amount
-    const recipientAddress = this.state.recipientAddress
-
     decryptMasterKeychain(password, encryptedBackupPhrase)
     .then((masterKeychain) => {
       const bitcoinPrivateKeychain = getBitcoinPrivateKeychain(masterKeychain)
       const bitcoinAddressHDNode = getBitcoinAddressNode(bitcoinPrivateKeychain, 0)
       const paymentKey = bitcoinAddressHDNode.keyPair.d.toBuffer(32).toString('hex')
+      const amount = this.state.amount
+      const recipientAddress = this.state.recipientAddress
+
       this.setState({
         lastAmount: amount
       })
 
       this.props.withdrawBitcoinClientSide(
-        this.props.regTestMode,`${paymentKey}01`, recipientAddress, amount)
+        this.props.regTestMode, `${paymentKey}01`, recipientAddress, amount)
       this.setState({
         amount: '',
         password: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,7 +2397,7 @@
             "regenerator-runtime": {
               "version": "0.11.0",
               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-              "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE=",
+              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
               "dev": true
             }
           }
@@ -2781,7 +2781,7 @@
     "bech32": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-0.0.3.tgz",
-      "integrity": "sha1-c2dHxKZTHF2JN9BABJjeMOk7L5w="
+      "integrity": "sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg=="
     },
     "beeper": {
       "version": "1.1.1",
@@ -2901,7 +2901,7 @@
     "bip39": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
-      "integrity": "sha1-oLitvxY/U0lfAPBdnt58JTaczxM=",
+      "integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
       "requires": {
         "create-hash": "1.1.3",
         "pbkdf2": "3.0.14",
@@ -2996,9 +2996,9 @@
       }
     },
     "blockstack": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-0.16.0.tgz",
-      "integrity": "sha512-SjnLZZINXMglZFy02gYYaxhLj6k7D2OzJu9hkGMNnhzOhKkuZfj8PKYufkzE0xmgJfURkapmqlg9lZtCeKrPyQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-0.16.1.tgz",
+      "integrity": "sha512-d4z9jELzeCwGwaSxR1xf0ULRPRTZfLVV3oegJiWAl/Z/fOqJaVEqjIsZqsJF5lE25Ac33tpFVZu81Bdrjdx7SQ==",
       "requires": {
         "ajv": "4.11.8",
         "bigi": "1.4.2",
@@ -3072,11 +3072,6 @@
             "bigi": "1.4.2",
             "safe-buffer": "5.1.1"
           }
-        },
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
         },
         "jsontokens": {
           "version": "0.7.7",
@@ -3981,7 +3976,7 @@
     "browser-sync": {
       "version": "2.18.13",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
-      "integrity": "sha1-wo3D6zvmfJepBwgrdyo3+RXBTX0=",
+      "integrity": "sha512-qhdrmgshVGwweogT/bdOKkZDxVxqiF4+9mibaDeAxvDBeoUtdgABk5x7YQ1KCcLRchAfv8AVtp9NuITl5CTNqg==",
       "dev": true,
       "requires": {
         "browser-sync-client": "2.5.1",
@@ -4715,7 +4710,7 @@
         "lodash.flatten": "4.4.0",
         "lodash.foreach": "4.5.0",
         "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.0",
+        "lodash.merge": "4.6.1",
         "lodash.pick": "4.4.0",
         "lodash.reduce": "4.6.0",
         "lodash.reject": "4.6.0",
@@ -4983,7 +4978,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "component-bind": {
@@ -5769,7 +5764,7 @@
     "custom-protocol-detection-blockstack": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/custom-protocol-detection-blockstack/-/custom-protocol-detection-blockstack-1.1.3.tgz",
-      "integrity": "sha1-6oR/0Kgbd5XXn3JJUCoa1p25Nlg="
+      "integrity": "sha512-iGwXqKU60VAzfjLF/amcJKQYMLeMlXAlzkZttakOQA7IjZw2WFSYAmn9a13d0LOBTzdVpbHnF+zZArNC9csiZw=="
     },
     "d": {
       "version": "0.1.1",
@@ -6967,7 +6962,7 @@
     "duplexify": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
+      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.0.0",
@@ -7433,6 +7428,11 @@
         }
       }
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -7715,7 +7715,7 @@
     "eslint-plugin-flowtype": {
       "version": "2.39.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.39.1.tgz",
-      "integrity": "sha1-tWJGIqA4i82Wn0NRExIy3LlknNU=",
+      "integrity": "sha512-RiQv+7Z9QDJuzt+NO8sYgkLGT+h+WeCrxP7y8lI7wpU41x3x/2o3PGtHk9ck8QnA9/mlbNcy/hG0eKvmd7npaA==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -8236,7 +8236,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
@@ -8597,7 +8597,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "slice-ansi": {
@@ -10005,7 +10005,7 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         }
       }
@@ -12612,7 +12612,7 @@
     "is-my-json-valid": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -13176,7 +13176,7 @@
     "js-base64": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha1-p5qSNmY3K1gPjif1GEXG9+j7+68=",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
     },
     "js-tokens": {
@@ -14210,9 +14210,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.0",
@@ -14344,7 +14344,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         }
       }
     },
@@ -14674,7 +14674,7 @@
     "mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha1-Q1MzeFR0fEjqSYMw3ANPn0u7zAs=",
+      "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
       "dev": true
     },
     "mime-db": {
@@ -15120,7 +15120,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
@@ -15264,7 +15264,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
@@ -17243,7 +17243,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -17356,7 +17356,7 @@
     "react-contextmenu": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/react-contextmenu/-/react-contextmenu-2.8.0.tgz",
-      "integrity": "sha1-sFVHe58nQKBpqwAan3Qwk1d0yrk=",
+      "integrity": "sha512-yGmdwZCzndsP5bl1DkfrMi12eroG8N2pfettvrDEnAoIv8CG3yDfmR8wBTS6Iiu87sCRdy5iHgX97zQv+cWppQ==",
       "requires": {
         "classnames": "2.2.5",
         "object-assign": "4.1.1"
@@ -17957,7 +17957,7 @@
     "redux-mock-store": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.3.0.tgz",
-      "integrity": "sha1-bt/vDSMy8gV2OBBp1tiJptCkRRw=",
+      "integrity": "sha512-TiwaDF4WLX/lJP0v1j4CMYUEfaIftTGuMUOYb7hmYJjLMAdgj2b/LOf+G9QDssNKFOpSl4B8St8TMUzF3hx92Q==",
       "dev": true
     },
     "redux-promise": {
@@ -17999,7 +17999,7 @@
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -18595,7 +18595,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true,
           "optional": true
         }
@@ -18766,7 +18766,7 @@
     "sha.js": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-      "integrity": "sha1-mPZIgEdLdPSji42p08Dy0QRjPn0=",
+      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -19123,7 +19123,7 @@
     "sourcemapped-stacktrace": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz",
-      "integrity": "sha1-F+BTdP94txqdia05daSfInJbqTU=",
+      "integrity": "sha512-pgHNUACbafkQ+M5zR00NSOtSKBc/i40prgN+SY07J/pghClwVNWNTTMa0JuXj4lriR2TvMKcPAHw5KN9tVFRhA==",
       "requires": {
         "source-map": "0.5.6"
       },
@@ -19425,7 +19425,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -20704,7 +20704,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "bigi": "^1.4.2",
     "bip39": "^2.2.0",
     "bitcoinjs-lib": "^3.2.0",
-    "blockstack": "0.16.0",
+    "blockstack": "0.16.1",
     "body-parser": "^1.16.1",
     "bootstrap": "^4.0.0-beta",
     "browser-stdout": "^1.3.0",


### PR DESCRIPTION
This performs bitcoin transactions client-side for the route

```
/wallet/send
```

To test this in regtest, I recommend firing up a regtest container:

```
$ IMAGE=$(docker run -dt -p 6270:6270 -p 16269:16269 -p 18332:18332 -e BLOCKSTACK_TEST_CLIENT_RPC_PORT
=6270 -e BLOCKSTACK_TEST_CLIENT_BIND=0.0.0.0 -e BLOCKSTACK_TEST_BITCOIND_ALLOWIP=172.17.0.0/16 quay.io/blockstack/inte
grationtests:master blockstack-test-scenario --interactive 2 blockstack_integration_tests.scenarios.browser_env)
$ docker logs -f $IMAGE | grep -q 'Test finished'
```

Then run the `dev-proxy` and `dev` npm targets:

```
$ npm i && npm run dev-proxy & npm run dev
```

Then open `localhost:3000/#coreAPIPassword=blockstack_integration_test_api_password&regtest=1`

After initializing an account, fund your regtest wallet from the `/send-core` endpoint.

Then you can send things around from the `/send/` endpoint.

To test in mainnet, just send a transaction from the `/send/` endpoint.


## Things that are different

If you enter a BTC amount _greater_ than the amount of bitcoin the wallet has, it will send the _max_ amount, not error. Do we want the old behavior instead, where it would error out? (For what it's worth, I found that old behavior really annoying, because I could never actually zero out my browser wallet).

## Things someone should look at

I don't _really_ know the right way to dispatch actions in reactJS, I just kind of fake knowledge of that. This method dispatches some `coreWalletX` actions. I don't think that should be a problem, but maybe it is, so someone should look at that.


Issue #1239