### PR TITLE
Fixes empty error message if you enter an invalid password when registering a username

### DIFF
--- a/app/js/utils/account-utils.js
+++ b/app/js/utils/account-utils.js
@@ -142,7 +142,7 @@ export function decryptMasterKeychain(password, encryptedBackupPhrase) {
       },
       error => {
         logger.error('decryptMasterKeychain: error', error)
-        reject('Incorrect password')
+        reject(new Error('Incorrect password'))
       }
     )
   })


### PR DESCRIPTION
In the `RegistrationSelectView`, when you attempt to register the username but have entered an incorrect password, an alert area appears but it doesn't show any error text. This is because the alert area text is set to `error.message` but the return value from `decryptBitcoinPrivateKey` (and `decryptMasterKeychain`) is a string and not an error object.

<img width="794" alt="error" src="https://user-images.githubusercontent.com/766596/37858178-be32d09c-2ecf-11e8-8c57-9cb7a59759f8.png">

Was thinking of just fixing this by changing `this.updateAlert('danger', error.message)` to `this.updateAlert('danger', error)` but it seems better practice to reject the original promise returned by `decryptMasterKeychain` with an actual error object. `decryptMasterKeychain` is used in two places in the repo and both places are already capable of handling an error object.

I also added in a super simple test case for `decryptMasterKeychain` to make sure it's still working & returns an error object when an error happens.

<img width="749" alt="blockstack_browser" src="https://user-images.githubusercontent.com/766596/37858171-a0c367ec-2ecf-11e8-9680-75d87ea99827.png">

Anyway, this is my first contribution to Blockstack so lemme know if I need to format something differently. 😀