### PR TITLE
add lower bound to wallet transfer amount

### DIFF
--- a/app/js/components/InputGroupSecondary.js
+++ b/app/js/components/InputGroupSecondary.js
@@ -6,6 +6,7 @@ class InputGroupSecondary extends Component {
     label: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     step: PropTypes.number,
+    min: PropTypes.string,
     name: PropTypes.string,
     data: PropTypes.object,
     onChange: PropTypes.func,
@@ -22,12 +23,16 @@ class InputGroupSecondary extends Component {
         type = "text",
         disabled = false,
         required = false,
-        step = 1
+        step = 1,
+        min = ""
     if (this.props.data && this.props.name) {
       value = this.props.data[this.props.name]
     }
     if (this.props.step) {
       step = this.props.step
+    }
+    if (this.props.min) {
+      min = this.props.min
     }
     if (this.props.type) {
       type = this.props.type
@@ -72,6 +77,7 @@ class InputGroupSecondary extends Component {
               type={type}
               required={required}
               step={step}
+              min={min}
               placeholder={
                 this.props.placeholder ? this.props.placeholder : this.props.label
               }

--- a/app/js/wallet/SendPage.js
+++ b/app/js/wallet/SendPage.js
@@ -187,6 +187,7 @@ class SendPage extends Component {
             type="number"
             required
             step={0.000001}
+            min="0"
           />
           <InputGroupSecondary
             data={this.state}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack-browser",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Background:
Right now in the wallet page, clicking on the down arrow in send input could decrement the amount to a negative value. Ideally we don't want that for a better UX.

Change:
add a min value for the wallet send amount.

Test:
manually tested decrementing at value 0 on the send input box will keep the value to send to 0. Increment works as expected.