### PR TITLE
Use cors-anywhere in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install cors-proxy
-RUN npm install -g corsproxy-https
+RUN npm install -g cors-anywhere
+RUN echo '#!/bin/bash' >> /usr/bin/corsproxy
+RUN echo 'node /src/blockstack-browser/corsproxy/corsproxy.js 0 0 0.0.0.0' >> /usr/bin/corsproxy
+RUN chmod +x /usr/bin/corsproxy
 
 # Alias the cors-proxy
 RUN ln /usr/bin/corsproxy /usr/bin/blockstack-cors-proxy


### PR DESCRIPTION
This changes the Docker container from using cors-proxy-https to cors-anywhere to start a CORS proxy.

You can test this by running:

```bash
$ docker pull quay.io/blockstack/blockstack-browser:feature_fix-cors-linux
$ docker run -d --name browser-cors -p 127.0.0.1:1337:1337 quay.io/blockstack/blockstack-browser:feature_fix-cors-linux blockstack-cors-proxy
$ curl -I http://localhost:1337/https://twitter.com/AaronBlankstein/status/918927256738811904
```

And you should get a 200 response.

If you run this on say, `develop`, you should get a 500:
```bash
$ docker stop browser-cors && docker rm browser-cors
$ docker pull quay.io/blockstack/blockstack-browser:develop
$ docker run -d --name browser-cors -p 127.0.0.1:1337:1337 quay.io/blockstack/blockstack-browser:develop blockstack-cors-proxy
$ curl -I http://localhost:1337/https://twitter.com/AaronBlankstein/status/918927256738811904
```


Fixes #1271 