### PR TITLE
Fix authentication with empty profiles

### DIFF
--- a/app/js/auth/components/AuthModal.js
+++ b/app/js/auth/components/AuthModal.js
@@ -12,7 +12,7 @@ import {
 } from 'blockstack'
 import Image from '../../components/Image'
 import { AppsNode } from '../../utils/account-utils'
-import { fetchProfileLocations } from '../../utils/profile-utils'
+import { fetchProfileLocations, getDefaultProfileUrl } from '../../utils/profile-utils'
 import { getTokenFileUrlFromZoneFile } from '../../utils/zone-utils'
 import { HDNode } from 'bitcoinjs-lib'
 import { validateScopes, appRequestSupportsDirectHub } from '../utils'
@@ -183,7 +183,13 @@ class AuthModal extends Component {
       if (!profileUrlPromise) {
         profileUrlPromise = fetchProfileLocations(
           gaiaUrlBase, identityAddress, gaiaBucketAddress, identityIndex)
-          .then(fetchProfileResp => fetchProfileResp.profileUrl)
+          .then(fetchProfileResp => {
+            if (fetchProfileResp && fetchProfileResp.profileUrl) {
+              return fetchProfileResp.profileUrl
+            } else {
+              return getDefaultProfileUrl(gaiaUrlBase, identityAddress)
+            }
+          })
       }
 
       profileUrlPromise.then((profileUrl) => {

--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -234,8 +234,8 @@ function refreshIdentities(api: {bitcoinAddressLookupUrl: string,
             return fetchProfileLocations('https://gaia.blockstack.org/hub',
                                          address, gaiaBucketAddress, index)
               .then(returnObject => {
-                const profile = returnObject.profile
-                if (profile) {
+                if (returnObject && returnObject.profile) {
+                  const profile = returnObject.profile
                   const zoneFile = ''
                   dispatch(updateProfile(index, profile, zoneFile))
                   let verifications = []

--- a/app/js/utils/profile-utils.js
+++ b/app/js/utils/profile-utils.js
@@ -104,6 +104,11 @@ export function getProfileFromTokens(tokenRecords, publicKeychain, silentVerify 
   return profile
 }
 
+export function getDefaultProfileUrl(gaiaUrlBase: string,
+                                     ownerAddress: string) {
+  return `${gaiaUrlBase}/${ownerAddress}/profile.json`
+}
+
 /**
  * Try to fetch and verify a profile from the historic set of default locations,
  * in order of recency. If all of them return 404s, or fail to validate, return null
@@ -143,7 +148,7 @@ export function fetchProfileLocations(gaiaUrlBase: string,
 
   const urls = []
   // the new default
-  urls.push(`${gaiaUrlBase}/${ownerAddress}/profile.json`)
+  urls.push(getDefaultProfileUrl(gaiaUrlBase, ownerAddress))
 
   // the 'indexed' URL --
   //  this is gaia/:firstAddress/:index/profile.json


### PR DESCRIPTION
This addresses #1274 --

A profile which hasn't been written yet 404s in the `fetchProfileLocations` function ---  leading to a `null` output, which ultimately breaks the auth modal.

This PR addresses that by checking for a null return and returning the default profile URL in that case.

You can test this by running this branch of the browser, and:

1. Test logging in with a brand new profile, which hasn't written it's profile yet (i.e., you haven't saved any changes to the profile)
2. Test logging in with a saved profile (a profile that _has_ already been written)
