### PR TITLE
Add ignores for express and styled-components to flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,6 @@
 [ignore]
+.*/node_modules/styled-components/*
+.*/node_modules/express/*
 .*/node_modules/bigi/*
 .*/node_modules/bower-json/*
 .*/node_modules/config-chain/*


### PR DESCRIPTION
This fixes an issue with a flow tests newly failing on circleCI.