### PR TITLE
[ESLint] Linting for tests/account/*

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,6 @@ build/*
 gulp/*
 flow-typed/*
 
-tests/account/*
 tests/fixtures/*
 tests/profiles/*
 tests/store/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,10 +20,13 @@
     "eol-last": 2,
     "import/no-duplicates": 2,
     "max-len": [
-      "error",
+      2,
+      100,
+      2,
       {
         "ignoreComments": true,
-        "ignoreStrings": true
+        "ignorePattern": "^import\\s.+\\sfrom\\s.+;$",
+        "ignoreUrls": true
       }
     ],
     "new-cap": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,7 @@
 {
   "extends": "airbnb",
   "parser": "babel-eslint",
-  "plugins": [
-    "react"
-  ],
+  "plugins": ["react"],
   "globals": {
     "proxyFetch": true
   },
@@ -14,43 +12,50 @@
   "env": {
     "browser": true,
     "es6": true,
-    "node": true,
+    "node": true
   },
   "rules": {
+    "camelcase": 2,
     "comma-dangle": ["error", "never"],
-    "quotes": [2, "single"],
     "eol-last": 2,
+    "import/no-duplicates": 2,
+    "max-len": [
+      "error",
+      {
+        "ignoreComments": true,
+        "ignoreStrings": true
+      }
+    ],
+    "new-cap": 0,
+    "no-console": 0,
     "no-debugger": 1,
-    "no-mixed-requires": 0,
-    "no-underscore-dangle": 0,
-    "no-multi-spaces": 0,
-    "no-trailing-spaces": 0,
+    "no-duplicate-imports": 0,
+    "no-else-return": 0,
     "no-extra-boolean-cast": 0,
+    "no-mixed-requires": 0,
+    "no-multi-spaces": 0,
+    "no-param-reassign": 0,
+    "no-trailing-spaces": 0,
     "no-undef": 2,
+    "no-underscore-dangle": 0,
     "no-unused-vars": 2,
     "no-var": 2,
-    "no-param-reassign": 0,
-    "no-else-return": 0,
-    "no-console": 0,
     "prefer-const": 2,
-    "new-cap": 0,
-    "camelcase": 2,
-    "semi": [2, "never"],
+    "quotes": [2, "single"],
+    "react/prop-types": 2,
+    "react/react-in-jsx-scope": 2,
+    "react/sort-comp": 0,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/react-in-jsx-scope": 2,
-    "react/prop-types": 2,
-    "react/sort-comp": 0,
-    "no-duplicate-imports": 0,
-    "import/no-duplicates": 2
+    "semi": [2, "never"]
   },
   "settings": {
     "react": {
-      "createClass": "createReactClass", // Regex for Component Factory to use, default to "createReactClass"
-      "pragma": "React",  // Pragma to use, default to "React"
-      "version": "15.0",// React version, default to the latest React stable release
-      "flowVersion": "0.53" // Flow version
+      "createClass": "createReactClass",
+      "pragma": "React",
+      "version": "15.0",
+      "flowVersion": "0.53"
     },
-    "propWrapperFunctions": [ "forbidExtraProps" ] // The names of any functions used to wrap the propTypes object, such as `forbidExtraProps`. If this isn't set, any propTypes wrapped in a function will be skipped.
+    "propWrapperFunctions": ["forbidExtraProps"]
   }
 }

--- a/tests/account/store/account/actions/async.test.js
+++ b/tests/account/store/account/actions/async.test.js
@@ -7,7 +7,6 @@ import { decrypt } from '../../../../../app/js/utils/encryption-utils'
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
-
 describe('Account Store: Async Actions', () => {
   afterEach(() => {
     nock.cleanAll()
@@ -16,15 +15,15 @@ describe('Account Store: Async Actions', () => {
   describe('initializeWallet', () => {
     it('creates an new account with a new master keychain', () => {
       const store = mockStore({})
-
       const password = 'password'
 
       return store.dispatch(AccountActions.initializeWallet(password))
-      .then(() => {
-        const actions = store.getActions()
-        assert.equal(actions.length, 1)
-        assert.equal(actions[0].type, 'CREATE_ACCOUNT')
-      })
+        .then(() => {
+          const actions = store.getActions()
+
+          assert.equal(actions.length, 1)
+          assert.equal(actions[0].type, 'CREATE_ACCOUNT')
+        })
     }).timeout(5000)
 
     it('restores an existing wallet and keychain', () => {
@@ -35,59 +34,60 @@ describe('Account Store: Async Actions', () => {
       const bitcoinPublicKeychain = 'xpub6Br2scNTh9Luk2VPebfEvjbWWC5WhvxpxgK8ap2qhYTS4xvZu8Y3G1npmx8DdvwUdCbtNb7qNLyTChKMbY8dThLV5Zvdq9AojQjxrM6gTC8'
       const identityPublicKeychain = 'xpub6B6tCCb8T5eXUKVYUoppmSi5KhNRboRJUwqHavxdvQTncfmBNFCX4Nq9w8DsfuS6AYPpBYRuS3dcUuyF8mQtwEydAEN3A4Cx6HDy58jpKEb'
       const firstBitcoinAddress = '112FogMTesWmLzkWbtKrSg3p9LK6Lucn4s'
-
       const identityAddresses = ['1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk']
 
-      const identityKeypairs =
-      [{ key: 'a29c3e73dba79ab0f84cb792bafd65ec71f243ebe67a7ebd842ef5cdce3b21eb',
+      const identityKeypairs = [{
+        key: 'a29c3e73dba79ab0f84cb792bafd65ec71f243ebe67a7ebd842ef5cdce3b21eb',
         keyID: '03e93ae65d6675061a167c34b8321bef87594468e9b2dd19c05a67a7b4caefa017',
         address: '1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk',
         appsNodeKey: 'xprvA1y4zBndD83n6PWgVH6ivkTpNQ2WU1UGPg9hWa2q8sCANa7YrYMZFHWMhrbpsarxXMuQRa4jtaT2YXugwsKrjFgn765tUHu9XjyiDFEjB7f',
-        salt: 'c15619adafe7e75a195a1a2b5788ca42e585a3fd181ae2ff009c6089de54ed9e' }]
+        salt: 'c15619adafe7e75a195a1a2b5788ca42e585a3fd181ae2ff009c6089de54ed9e'
+      }]
 
       return store.dispatch(AccountActions.initializeWallet(password, backupPhrase))
-      .then(() => {
-        const actions = store.getActions()
-        assert.equal(actions.length, 1)
-        assert.equal(actions[0].bitcoinPublicKeychain, bitcoinPublicKeychain)
-        assert.equal(actions[0].identityPublicKeychain, identityPublicKeychain)
-        assert.equal(actions[0].firstBitcoinAddress, firstBitcoinAddress)
-        assert.deepEqual(actions[0].identityAddresses, identityAddresses)
-        assert.deepEqual(actions[0].identityKeypairs, identityKeypairs)
-      })
+        .then(() => {
+          const actions = store.getActions()
+
+          assert.equal(actions.length, 1)
+          assert.equal(actions[0].bitcoinPublicKeychain, bitcoinPublicKeychain)
+          assert.equal(actions[0].identityPublicKeychain, identityPublicKeychain)
+          assert.equal(actions[0].firstBitcoinAddress, firstBitcoinAddress)
+          assert.deepEqual(actions[0].identityAddresses, identityAddresses)
+          assert.deepEqual(actions[0].identityKeypairs, identityKeypairs)
+        })
     }).timeout(5000)
 
     it('generates and restores the same wallet', () => {
       const store1 = mockStore({})
-
       const password = 'password'
 
       return store1.dispatch(AccountActions.initializeWallet(password))
-      .then(() => {
-        const actions1 = store1.getActions()
-        assert.equal(actions1.length, 1)
-        assert.equal(actions1[0].type, 'CREATE_ACCOUNT')
+        .then(() => {
+          const actions1 = store1.getActions()
 
-        const encryptedBackupPhrase = actions1[0].encryptedBackupPhrase
-        const identityPublicKeychain = actions1[0].identityPublicKeychain
-        const bitcoinPublicKeychain = actions1[0].bitcoinPublicKeychain
+          assert.equal(actions1.length, 1)
+          assert.equal(actions1[0].type, 'CREATE_ACCOUNT')
 
+          const encryptedBackupPhrase = actions1[0].encryptedBackupPhrase
+          const identityPublicKeychain = actions1[0].identityPublicKeychain
+          const bitcoinPublicKeychain = actions1[0].bitcoinPublicKeychain
 
+          return decrypt(new Buffer(encryptedBackupPhrase, 'hex'), password)
+            .then((plaintextBuffer) => {
+              const backupPhrase = plaintextBuffer.toString()
+              const store2 = mockStore({})
 
-        return decrypt(new Buffer(encryptedBackupPhrase, 'hex'), password)
-        .then((plaintextBuffer) => {
-          const backupPhrase = plaintextBuffer.toString()
-          const store2 = mockStore({})
-          return store2.dispatch(AccountActions.initializeWallet(password, backupPhrase))
-          .then(() => {
-            const actions2 = store2.getActions()
-            assert.equal(actions2.length, 1)
-            assert.equal(actions2[0].type, 'CREATE_ACCOUNT')
-            assert.equal(actions2[0].identityPublicKeychain, identityPublicKeychain)
-            assert.equal(actions2[0].bitcoinPublicKeychain, bitcoinPublicKeychain)
-          })
+              return store2.dispatch(AccountActions.initializeWallet(password, backupPhrase))
+                .then(() => {
+                  const actions2 = store2.getActions()
+
+                  assert.equal(actions2.length, 1)
+                  assert.equal(actions2[0].type, 'CREATE_ACCOUNT')
+                  assert.equal(actions2[0].identityPublicKeychain, identityPublicKeychain)
+                  assert.equal(actions2[0].bitcoinPublicKeychain, bitcoinPublicKeychain)
+                })
+            })
         })
-      })
     }).timeout(7000) // encryption & decryption is slow
   })
 })

--- a/tests/account/store/account/actions/async.test.js
+++ b/tests/account/store/account/actions/async.test.js
@@ -29,10 +29,10 @@ describe('Account Store: Async Actions', () => {
     it('restores an existing wallet and keychain', () => {
       const store = mockStore({})
       const password = 'password'
-      const backupPhrase = 'sound idle panel often situate develop unit text design antenna vendor screen opinion balcony share trigger accuse scatter visa uniform brass update opinion media'
+      const backupPhrase = 'sound idle panel often situate develop unit text design antenna vendor screen opinion balcony share trigger accuse scatter visa uniform brass update opinion media' // eslint-disable-line max-len
 
-      const bitcoinPublicKeychain = 'xpub6Br2scNTh9Luk2VPebfEvjbWWC5WhvxpxgK8ap2qhYTS4xvZu8Y3G1npmx8DdvwUdCbtNb7qNLyTChKMbY8dThLV5Zvdq9AojQjxrM6gTC8'
-      const identityPublicKeychain = 'xpub6B6tCCb8T5eXUKVYUoppmSi5KhNRboRJUwqHavxdvQTncfmBNFCX4Nq9w8DsfuS6AYPpBYRuS3dcUuyF8mQtwEydAEN3A4Cx6HDy58jpKEb'
+      const bitcoinPublicKeychain = 'xpub6Br2scNTh9Luk2VPebfEvjbWWC5WhvxpxgK8ap2qhYTS4xvZu8Y3G1npmx8DdvwUdCbtNb7qNLyTChKMbY8dThLV5Zvdq9AojQjxrM6gTC8' // eslint-disable-line max-len
+      const identityPublicKeychain = 'xpub6B6tCCb8T5eXUKVYUoppmSi5KhNRboRJUwqHavxdvQTncfmBNFCX4Nq9w8DsfuS6AYPpBYRuS3dcUuyF8mQtwEydAEN3A4Cx6HDy58jpKEb' // eslint-disable-line max-len
       const firstBitcoinAddress = '112FogMTesWmLzkWbtKrSg3p9LK6Lucn4s'
       const identityAddresses = ['1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk']
 
@@ -40,7 +40,7 @@ describe('Account Store: Async Actions', () => {
         key: 'a29c3e73dba79ab0f84cb792bafd65ec71f243ebe67a7ebd842ef5cdce3b21eb',
         keyID: '03e93ae65d6675061a167c34b8321bef87594468e9b2dd19c05a67a7b4caefa017',
         address: '1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk',
-        appsNodeKey: 'xprvA1y4zBndD83n6PWgVH6ivkTpNQ2WU1UGPg9hWa2q8sCANa7YrYMZFHWMhrbpsarxXMuQRa4jtaT2YXugwsKrjFgn765tUHu9XjyiDFEjB7f',
+        appsNodeKey: 'xprvA1y4zBndD83n6PWgVH6ivkTpNQ2WU1UGPg9hWa2q8sCANa7YrYMZFHWMhrbpsarxXMuQRa4jtaT2YXugwsKrjFgn765tUHu9XjyiDFEjB7f', // eslint-disable-line max-len
         salt: 'c15619adafe7e75a195a1a2b5788ca42e585a3fd181ae2ff009c6089de54ed9e'
       }]
 

--- a/tests/account/store/account/actions/sync.test.js
+++ b/tests/account/store/account/actions/sync.test.js
@@ -1,3 +1,3 @@
-import { AccountActions } from '../../../../../app/js/account/store/account'
+// import { AccountActions } from '../../../../../app/js/account/store/account'
 
 describe('Account Store: Sync Actions', () => {})

--- a/tests/account/store/account/actions/sync.test.js
+++ b/tests/account/store/account/actions/sync.test.js
@@ -1,5 +1,3 @@
 import { AccountActions } from '../../../../../app/js/account/store/account'
 
-describe('Account Store: Sync Actions', () => {
-
-})
+describe('Account Store: Sync Actions', () => {})

--- a/tests/account/store/account/reducer.test.js
+++ b/tests/account/store/account/reducer.test.js
@@ -1,6 +1,6 @@
 import { AccountActions, AccountReducer } from '../../../../app/js/account/store/account'
 
-const initialState = {
+let initialState = {
   accountCreated: false,
   promptedForEmail: false,
   email: null,
@@ -31,11 +31,12 @@ describe('Account Store: AccountReducer', () => {
   it('should return the proper initial state', () => {
     assert.deepEqual(
       AccountReducer(undefined, {}),
-      initialState)
+      initialState
+    )
   })
 
   it('should calculate the next bitcoin address', () => {
-    const initialState = {
+    initialState = {
       identityAccount: {
         publicKeychain: 'xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR',
         addresses: ['1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6'],
@@ -49,49 +50,45 @@ describe('Account Store: AccountReducer', () => {
       }
     }
     const action = AccountActions.newBitcoinAddress()
-
     const expectedState = {
-         "bitcoinAccount": {
-           "addressIndex": 1,
-           "addresses": [
-             "16KyES12ATkeM8DNbdTAWFtAPQFNXsFaB1",
-             "1K2GerUJeysnNYJEB9nZPykPmuAwKpNc9k"
-           ],
-           "balances": {
-             "total": 0
-           },
-           "publicKeychain": "xpub6DPVcgkLNGyJ658Zd77XVCtKMAcyNWyGwtzxfzTt2XMhMnc6pkYQXru3BSFHbe4wErGeWtZ8WEVnf74ev7ypn6aFysKGcT3AJ1LrGG2ZDwJ",
-         },
-         "identityAccount": {
-           "addressIndex": 0,
-           "addresses": [
-             "1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6"
-           ],
-           "publicKeychain": "xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR"
-         }
-       }
+      bitcoinAccount: {
+        addressIndex: 1,
+        addresses: [
+          "16KyES12ATkeM8DNbdTAWFtAPQFNXsFaB1",
+          "1K2GerUJeysnNYJEB9nZPykPmuAwKpNc9k"
+        ],
+        balances: {
+          "total": 0
+        },
+        publicKeychain: "xpub6DPVcgkLNGyJ658Zd77XVCtKMAcyNWyGwtzxfzTt2XMhMnc6pkYQXru3BSFHbe4wErGeWtZ8WEVnf74ev7ypn6aFysKGcT3AJ1LrGG2ZDwJ",
+      },
+      identityAccount: {
+        addressIndex: 0,
+        addresses: ["1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6"],
+        publicKeychain: "xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR"
+      }
+    }
 
     const actualState = AccountReducer(initialState, action)
 
-    assert.deepEqual(actualState,
-      expectedState)
+    assert.deepEqual(actualState, expectedState)
   })
 
   it('should indicated backup phrase has been displayed', () => {
     const action = AccountActions.updateViewedRecoveryCode()
     const actualState = AccountReducer(initialState, action)
+
     assert(actualState.viewedRecoveryCode, true)
   })
 
   it('increment the identity address index', () => {
-    const initialState = {
+    initialState = {
       identityAccount: {
         addressIndex: 0
       }
     }
 
     const action = AccountActions.incrementIdentityAddressIndex()
-
     const expectedState = {
       identityAccount: {
         addressIndex: 1
@@ -100,7 +97,6 @@ describe('Account Store: AccountReducer', () => {
 
     const actualState = AccountReducer(initialState, action)
 
-    assert.deepEqual(actualState,
-      expectedState)
+    assert.deepEqual(actualState, expectedState)
   })
 })

--- a/tests/account/store/account/reducer.test.js
+++ b/tests/account/store/account/reducer.test.js
@@ -1,5 +1,10 @@
 import { AccountActions, AccountReducer } from '../../../../app/js/account/store/account'
 
+// eslint-disable-next-line max-len
+const BITCOIN_ACCOUNT_KEYCHAIN = 'xpub6DPVcgkLNGyJ658Zd77XVCtKMAcyNWyGwtzxfzTt2XMhMnc6pkYQXru3BSFHbe4wErGeWtZ8WEVnf74ev7ypn6aFysKGcT3AJ1LrGG2ZDwJ'
+// eslint-disable-next-line max-len
+const IDENTITY_ACCOUNT_KEYCHAIN = 'xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR'
+
 let initialState = {
   accountCreated: false,
   promptedForEmail: false,
@@ -38,12 +43,12 @@ describe('Account Store: AccountReducer', () => {
   it('should calculate the next bitcoin address', () => {
     initialState = {
       identityAccount: {
-        publicKeychain: 'xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR',
+        publicKeychain: IDENTITY_ACCOUNT_KEYCHAIN,
         addresses: ['1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6'],
         addressIndex: 0
       },
       bitcoinAccount: {
-        publicKeychain: 'xpub6DPVcgkLNGyJ658Zd77XVCtKMAcyNWyGwtzxfzTt2XMhMnc6pkYQXru3BSFHbe4wErGeWtZ8WEVnf74ev7ypn6aFysKGcT3AJ1LrGG2ZDwJ',
+        publicKeychain: BITCOIN_ACCOUNT_KEYCHAIN,
         addresses: ['16KyES12ATkeM8DNbdTAWFtAPQFNXsFaB1'],
         balances: { total: 0.0 },
         addressIndex: 0
@@ -54,18 +59,18 @@ describe('Account Store: AccountReducer', () => {
       bitcoinAccount: {
         addressIndex: 1,
         addresses: [
-          "16KyES12ATkeM8DNbdTAWFtAPQFNXsFaB1",
-          "1K2GerUJeysnNYJEB9nZPykPmuAwKpNc9k"
+          '16KyES12ATkeM8DNbdTAWFtAPQFNXsFaB1',
+          '1K2GerUJeysnNYJEB9nZPykPmuAwKpNc9k'
         ],
         balances: {
-          "total": 0
+          total: 0
         },
-        publicKeychain: "xpub6DPVcgkLNGyJ658Zd77XVCtKMAcyNWyGwtzxfzTt2XMhMnc6pkYQXru3BSFHbe4wErGeWtZ8WEVnf74ev7ypn6aFysKGcT3AJ1LrGG2ZDwJ",
+        publicKeychain: BITCOIN_ACCOUNT_KEYCHAIN
       },
       identityAccount: {
         addressIndex: 0,
-        addresses: ["1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6"],
-        publicKeychain: "xpub69qePe4LJAcLtQvdginvTYNoFPzm2kZNzCbwY62X31Grxw85RQVnQ81npSRtEGuGF8x9jQGE2sMTmLn2AA8kXwNdiiqgS74muDeDjivLVwR"
+        addresses: ['1D6WztrjTkKkrcGBL1pqfCJFnCbmQtjPh6'],
+        publicKeychain: IDENTITY_ACCOUNT_KEYCHAIN
       }
     }
 

--- a/tests/account/store/settings/actions/async.test.js
+++ b/tests/account/store/settings/actions/async.test.js
@@ -7,7 +7,6 @@ import btcPrice from '../../../../fixtures/btcprice'
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
-
 describe('Settings Store: Async Actions', () => {
   afterEach(() => {
     nock.cleanAll()
@@ -16,8 +15,8 @@ describe('Settings Store: Async Actions', () => {
   describe('refreshBtcPrice', () => {
     it('returns btc price', () => {
       nock('https://www.bitstamp.net')
-      .get('/api/v2/ticker/btcusd/')
-      .reply(200, btcPrice, { 'Content-Type': 'application/json' })
+        .get('/api/v2/ticker/btcusd/')
+        .reply(200, btcPrice, { 'Content-Type': 'application/json' })
 
       const store = mockStore({
         api: {
@@ -27,12 +26,14 @@ describe('Settings Store: Async Actions', () => {
 
       const btcPriceUrl = 'https://www.bitstamp.net/api/v2/ticker/btcusd/'
       return store.dispatch(SettingsActions.refreshBtcPrice(btcPriceUrl))
-      .then(() => {
-        const expectedActions = [{ type: 'UPDATE_BTC_PRICE',
-                                   price: '1168.98'
-                                 }]
-        assert.deepEqual(store.getActions(), expectedActions)
-      })
+        .then(() => {
+          const expectedActions = [{
+            type: 'UPDATE_BTC_PRICE',
+            price: '1168.98'
+          }]
+
+          assert.deepEqual(store.getActions(), expectedActions)
+        })
     })
   })
 })

--- a/tests/account/store/settings/actions/sync.test.js
+++ b/tests/account/store/settings/actions/sync.test.js
@@ -4,9 +4,7 @@ import DEFAULT_API from '../../../../../app/js/account/store/settings/default'
 describe('Settings Store: Sync Actions', () => {
   describe('resetApi', () => {
     it('should return an action of type UPDATE_API with default API', () => {
-      const initialApi = {
-        lookupUrl: 'https://example.com/v1/lookup'
-      }
+      const initialApi = { lookupUrl: 'https://example.com/v1/lookup' }
       const expectedResult = {
         type: 'UPDATE_API',
         api: Object.assign({}, DEFAULT_API)
@@ -16,6 +14,7 @@ describe('Settings Store: Sync Actions', () => {
         assert.deepEqual(action, expectedResult)
         assert.notDeepEqual(action.api, initialApi)
       }
+
       actualResult(dispatch)
     })
 
@@ -39,15 +38,14 @@ describe('Settings Store: Sync Actions', () => {
         assert.equal(action.api.coreAPIPassword, initialApi.coreAPIPassword)
         assert.equal(action.api.gaiaHubConfig, initialApi.gaiaHubConfig)
       }
+
       actualResult(dispatch)
     })
   })
 
   describe('updateApi', () => {
     it('should return an action of type UPDATE_API with new API', () => {
-      const initialApi = {
-        lookupUrl: 'https://example.com/v1/lookup'
-      }
+      const initialApi = { lookupUrl: 'https://example.com/v1/lookup' }
       const expectedResult = {
         type: 'UPDATE_API',
         api: {
@@ -57,6 +55,7 @@ describe('Settings Store: Sync Actions', () => {
       const actualResult = SettingsActions.updateApi({
         lookupUrl: 'https://example.com/v2/lookup'
       })
+
       assert.deepEqual(actualResult, expectedResult)
       assert.notDeepEqual(actualResult.api, initialApi)
     })
@@ -69,6 +68,7 @@ describe('Settings Store: Sync Actions', () => {
         price: '10000.00'
       }
       const actualResult = SettingsActions.updateBtcPrice('10000.00')
+
       assert.deepEqual(actualResult, expectedResult)
     })
   })

--- a/tests/account/store/settings/reducer.test.js
+++ b/tests/account/store/settings/reducer.test.js
@@ -1,15 +1,16 @@
 import { SettingsActions, SettingsReducer } from '../../../../app/js/account/store/settings'
 import DEFAULT_API from '../../../../app/js/account/store/settings/default'
 
-
 describe('Settings Store: SettingsReducer', () => {
   it('should return the proper initial state', () => {
     const initialState = {
       api: Object.assign({}, DEFAULT_API)
     }
+
     assert.deepEqual(
       SettingsReducer(undefined, {}),
-      initialState)
+      initialState
+    )
   })
 
   it('should update api', () => {
@@ -19,68 +20,67 @@ describe('Settings Store: SettingsReducer', () => {
       }
     }
 
-    const newApi = {
-      lookupURL: 'https://example/v2/lookup/'
-    }
-
+    const newApi = { lookupURL: 'https://example/v2/lookup/' }
     const action = SettingsActions.updateApi(newApi)
+
     assert.deepEqual(
       SettingsReducer(state, action),
-      {
-        api: newApi
-      })
+      { api: newApi }
+    )
   })
 
   it('should return the initial state', () => {
     assert.deepEqual(
       SettingsReducer(undefined, {}),
-      {
-        api: DEFAULT_API
-      })
+      { api: DEFAULT_API }
+    )
   })
 
   it('should add missing api urls', () => {
     const initialState = {
       api: Object.assign({}, DEFAULT_API)
     }
+
     delete initialState.api.nameLookupUrl
     assert(initialState.api.nameLookupUrl === undefined)
 
     assert.deepEqual(
       SettingsReducer(initialState, {}),
-      {
-        api: DEFAULT_API
-      })
+      { api: DEFAULT_API }
+    )
   })
 
   it('should not overwrite existing api urls', () => {
     const initialState = {
       api: Object.assign({}, DEFAULT_API)
     }
+
     initialState.api.nameLookupUrl = 'test'
     assert(initialState.api.nameLookupUrl === 'test')
 
     const state = SettingsReducer(initialState, {})
     assert(state.api.nameLookupUrl === 'test')
-    assert.notDeepEqual(state,
-      {
-        api: DEFAULT_API
-      })
+
+    assert.notDeepEqual(
+      state,
+      { api: DEFAULT_API }
+    )
   })
 
   it('should not overwrite existing api urls that are null', () => {
     const initialState = {
       api: Object.assign({}, DEFAULT_API)
     }
+
     initialState.api.nameLookupUrl = null
     assert(initialState.api.nameLookupUrl === null)
 
     const state = SettingsReducer(initialState, {})
     assert(state.api.nameLookupUrl === null)
-    assert.notDeepEqual(state,
-      {
-        api: DEFAULT_API
-      })
+    assert.notDeepEqual(
+      state,
+      { api: DEFAULT_API }
+    )
   })
 
   it('should not overwrite existing api urls that are blank strings', () => {
@@ -92,10 +92,10 @@ describe('Settings Store: SettingsReducer', () => {
 
     const state = SettingsReducer(initialState, {})
     assert(state.api.nameLookupUrl === '')
-    assert.notDeepEqual(state,
-      {
-        api: DEFAULT_API
-      })
+    assert.notDeepEqual(
+      state,
+      { api: DEFAULT_API }
+    )
   })
 
   it('should update the bitcoin price', () => {

--- a/tests/account/utils.test.js
+++ b/tests/account/utils.test.js
@@ -1,14 +1,13 @@
-import {
-  uploadPhoto, uploadProfile
- } from '../../app/js/account/utils'
+import { uploadProfile } from '../../app/js/account/utils'
 import { ECPair } from 'bitcoinjs-lib'
 import { BitcoinKeyPairs } from '../fixtures/bitcoin'
 import nock from 'nock'
 
-const mockHubInfoResponse = { "challenge_text":
-                              "[\"gaiahub\",\"2018\",\"storage.blockstack.org\",\"blockstack_storage_please_sign\"]",
-                              "read_url_prefix":
-                              "https://gaia.blockstack.org/hub/" }
+const mockHubInfoResponse = {
+  // eslint-disable-next-line max-len
+  challenge_text: '["gaiahub","2018","storage.blockstack.org","blockstack_storage_please_sign"]',
+  read_url_prefix: 'https://gaia.blockstack.org/hub/'
+}
 
 const globalAPIConfig = {
   gaiaHubConfig: {
@@ -25,13 +24,12 @@ describe('upload-profile', () => {
     nock('https://hub.blockstack.org')
       .get('/hub_info')
       .reply(200, mockHubInfoResponse)
-
   })
 
-  afterEach(() => {
-  })
+  afterEach(() => {})
 
   describe('uploadProfile', () => {
+    // eslint-disable-next-line max-len
     it('should upload to the zonefile entry location, using the global uploader if necessary', () => {
       const ecPair = ECPair.fromWIF(BitcoinKeyPairs.test1.wif)
       const address = ecPair.getAddress()
@@ -43,12 +41,16 @@ describe('upload-profile', () => {
 
       const hubAddress = globalAPIConfig.gaiaHubConfig.address
 
-      const mockResponseBody = {"publicURL":`https://gaia.blockstack.org/hub/${hubAddress}/foo-profile.json`}
+      const mockResponseBody = {
+        publicURL: `https://gaia.blockstack.org/hub/${hubAddress}/foo-profile.json`
+      }
+
       // mock gaia hub
       nock('https://hub.blockstack.org')
         .post(`/store/${hubAddress}/foo-profile.json`)
         .reply(200, mockResponseBody)
 
+      // eslint-disable-next-line max-len
       const zoneFile = `$ORIGIN satoshi.id\n$TTL 3600\n_http._tcp\tIN\tURI\t10\t1\t"https://gaia.blockstack.org/hub/${hubAddress}/foo-profile.json"\n\n`
 
       const identity = { zoneFile }
@@ -68,7 +70,10 @@ describe('upload-profile', () => {
         key
       }
 
-      const mockResponseBody = {"publicURL":`https://gaia.blockstack.org/hub/${address}/profile.json`}
+      const mockResponseBody = {
+        publicURL: `https://gaia.blockstack.org/hub/${address}/profile.json`
+      }
+
       // mock gaia hub
       nock('https://hub.blockstack.org')
         .post(`/store/${address}/profile.json`)
@@ -91,6 +96,7 @@ describe('upload-profile', () => {
         key
       }
 
+      // eslint-disable-next-line max-len
       const zoneFile = `$ORIGIN satoshi.id\n$TTL 3600\n_http._tcp\tIN\tURI\t10\t1\t"https://potato.blockstack.org/hub/${address}/foo-profile.json"\n\n`
 
       const identity = { zoneFile }
@@ -100,7 +106,5 @@ describe('upload-profile', () => {
           `https://gaia.blockstack.org/hub/${address}/profile.json`, x))
         .catch(() => assert.fail())
     })
-
   })
-
 })


### PR DESCRIPTION
## Tasks
- [x] Removed `tests/account/*` from `.eslintignore`
- [x] Added `max-len` rule support for longer strings and comments
  * addresses tend to be rather large strings
- [x] Sorted ESLint rules alphabetically
- [x] Code clean up and linting efforts for all `tests/account/*` files

## Discussion
Wasn't sure how to handle the edge cases for `max-len`. When the title of a an `it` test description is longer, ESLint still triggers an error. I'm locally disabling those for now. Happy to discuss if you'd like to extend `max-len` to 100, or follow another approach.