### PR TITLE
Component Tests for blockstack-browser

### DIFF
--- a/app/js/account/AccountApp.js
+++ b/app/js/account/AccountApp.js
@@ -16,7 +16,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({}, dispatch)
 }
 
-class AccountApp extends Component {
+export class AccountApp extends Component {
   static propTypes = {
     children: PropTypes.object,
     storageConnected: PropTypes.bool.isRequired,

--- a/app/js/account/AccountMenu.js
+++ b/app/js/account/AccountMenu.js
@@ -8,7 +8,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({}, dispatch)
 }
 
-class AccountMenu extends Component {
+export class AccountMenu extends Component {
   static propTypes = {
     children: PropTypes.object
   }

--- a/app/js/account/ApiSettingsPage.js
+++ b/app/js/account/ApiSettingsPage.js
@@ -20,7 +20,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators(SettingsActions, dispatch)
 }
 
-class ApiSettingsPage extends Component {
+export class ApiSettingsPage extends Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
     updateApi: PropTypes.func.isRequired,

--- a/app/js/components/Completion.js
+++ b/app/js/components/Completion.js
@@ -1,19 +1,11 @@
-import React, { Component } from 'react'
-import { Link } from 'react-router'
+import React from 'react'
 
-class Completion extends Component {
-  static propTypes = {
-  }
-
-  render() {
-    return (
-      <div class="tooltip tooltip-bottom " role="tooltip">
-        <div class="tooltip-inner">
-          Tooltip on the bottom
-        </div>
-      </div>
-    )
-  }
-}
+const Completion = () => (
+  <div className="tooltip tooltip-bottom" role="tooltip">
+    <div className="tooltip-inner">
+      Tooltip on the bottom
+    </div>
+  </div>
+)
 
 export default Completion

--- a/app/js/components/HomeButton.js
+++ b/app/js/components/HomeButton.js
@@ -3,9 +3,6 @@ import React, { Component } from 'react'
 import { Link } from 'react-router'
 
 class HomeButton extends Component {
-  static propTypes = {
-  }
-
   render() {
     return (
       <Link to="/">

--- a/app/js/components/SupportButton.js
+++ b/app/js/components/SupportButton.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const SupportButton = props => (
   <div className="support-floater clickable" onClick={props.onClick}>
     ?

--- a/app/js/welcome/components/EnterEmailView.js
+++ b/app/js/welcome/components/EnterEmailView.js
@@ -10,10 +10,9 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators(Object.assign({}, AccountActions), dispatch)
 }
 
-class EnterEmailView extends Component {
+export class EnterEmailView extends Component {
   static propTypes = {
-    emailNotifications: PropTypes.func.isRequired,
-    skipEmailBackup: PropTypes.func.isRequired
+    emailNotifications: PropTypes.func.isRequired
   }
 
   constructor(props) {
@@ -24,7 +23,6 @@ class EnterEmailView extends Component {
     }
     this.onToggle = this.onToggle.bind(this)
     this.onValueChange = this.onValueChange.bind(this)
-    this.skip = this.skip.bind(this)
     this.saveEmail = this.saveEmail.bind(this)
   }
 
@@ -43,11 +41,6 @@ class EnterEmailView extends Component {
   saveEmail(event) {
     event.preventDefault()
     this.props.emailNotifications(this.state.email, this.state.optIn)
-  }
-
-  skip(event) {
-    event.preventDefault()
-    this.props.skipEmailBackup()
   }
 
   render() {

--- a/tests/account/AccountApp.test.js
+++ b/tests/account/AccountApp.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { AccountApp } from '../../app/js/account/AccountApp'
+
+describe('AccountApp', () => {
+  let props;
+  let wrapper;
+
+  before(() => {
+    props = {
+      children: {},
+      storageConnected: true,
+      location: {
+        pathname: '/not-account'
+      }
+    }
+
+    wrapper = shallow(<AccountApp {...props} />)
+  })
+
+  it('renders the NavBar', () => {
+    expect(wrapper.find('Navbar').length).to.equal(1)
+  })
+
+  it('renders the SecondaryNavBar', () => {
+    expect(wrapper.find('SecondaryNavBar').length).to.equal(1)
+  })
+})

--- a/tests/account/AccountMenu.test.js
+++ b/tests/account/AccountMenu.test.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { AccountMenu } from '../../app/js/account/AccountMenu'
+
+describe('AccountMenu', () => {
+  let props;
+  let wrapper;
+
+  before(() => {
+    props = {
+      children: {},
+    }
+
+    wrapper = shallow(<AccountMenu {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('.list-group').length).to.equal(1)
+  })
+
+  it('renders the 5 Link Components', () => {
+    expect(wrapper.find('Link').length).to.equal(5)
+  })
+})

--- a/tests/account/ApiSettingsPage.test.js
+++ b/tests/account/ApiSettingsPage.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { ApiSettingsPage } from '../../app/js/account/ApiSettingsPage'
+
+describe('ApiSettingsPage', () => {
+  let props;
+  let wrapper;
+
+  before(() => {
+    props = {
+      api: { apiCustomizationEnabled: true },
+      updateApi: sinon.spy(),
+      resetApi: sinon.spy()
+    }
+
+    wrapper = shallow(<ApiSettingsPage {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('.m-t-10').length).to.equal(1)
+    expect(wrapper.find('.m-t-10').text()).to.contain('Blockstack API Options')
+  })
+
+  it('renders all the InputGroup(s)', () => {
+    expect(wrapper.find('InputGroup').length).to.equal(18)
+  })
+})

--- a/tests/account/components/DeleteAccountModal.test.js
+++ b/tests/account/components/DeleteAccountModal.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import DeleteAccountModal from '../../../app/js/account/components/DeleteAccountModal'
+
+describe('<DeleteAccountModal />', () => {
+  let props;
+  let wrapper;
+
+  before(() => {
+    props = {
+      isOpen: true,
+      contentLabel: 'my-content-label',
+      closeModal: sinon.spy(),
+      deleteAccount: sinon.spy()
+    }
+
+    wrapper = shallow(<DeleteAccountModal {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('Modal').length).to.equal(1)
+  })
+
+  it('calls deleteAccount prop function', () => {
+    wrapper.find('.btn-danger').simulate('click')
+    expect(props.deleteAccount.called).to.be.true
+  })
+})

--- a/tests/components/ActionItem.test.js
+++ b/tests/components/ActionItem.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import ActionItem from '../../app/js/components/ActionItem'
+
+describe('<ActionItem />', () => {
+  describe('incomplete', () => {
+    let wrapper
+    const props = {
+      action: 'action-1',
+      destinationUrl: 'https://blockstack.com/actions/action-1',
+      destinationName: 'action-1-name',
+      completed: false
+    }
+
+    before(() => {
+      wrapper = shallow(<ActionItem {...props} />)
+    })
+
+    it('renders the component', () => {
+      expect(wrapper.find('.action-item').length).to.equal(1)
+    })
+
+    it('renders the toolTip a tag', () => {
+      expect(wrapper.find('.tooltip-link').length).to.equal(1)
+    })
+  })
+
+  describe('complete', () => {
+    let wrapper
+    const props = {
+      action: 'action-1',
+      destinationUrl: 'https://blockstack.com/actions/action-1',
+      destinationName: 'action-1-name',
+      completed: true
+    }
+
+    before(() => {
+      wrapper = shallow(<ActionItem {...props} />)
+    })
+
+    it('does not render the component', () => {
+      expect(wrapper.find('.action-item').length).to.equal(0)
+    })
+  })
+})

--- a/tests/components/Alert.test.js
+++ b/tests/components/Alert.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Alert from '../../app/js/components/Alert'
+
+describe('<Alert />', () => {
+  describe('url exist and state is shown', () => {
+    let wrapper
+    const props = {
+      messsage: 'error-1',
+      url: 'https://blockstack.com/alert',
+      status: 'status-good'
+    }
+
+    before(() => {
+      wrapper = shallow(<Alert {...props} />)
+    })
+
+    it('renders the component', () => {
+      expect(wrapper.find('.alert').length).to.equal(1)
+    })
+
+    it('renders the proper alert status', () => {
+      expect(wrapper.find('.alert-status-good').length).to.equal(1)
+    })
+
+    it('renders the Link Component', () => {
+      expect(wrapper.find('Link').length).to.equal(1)
+    })
+
+    it('hides the content on button click', () => {
+      wrapper.find('.close').simulate('click')
+      expect(wrapper.find('.alert').length).to.equal(0)
+    })
+  })
+
+  describe('url does not exist', () => {
+    let wrapper
+    const props = {
+      messsage: 'error-1',
+      url: null,
+      status: 'status-good'
+    }
+
+    before(() => {
+      wrapper = shallow(<Alert {...props} />)
+    })
+
+    it('renders the component', () => {
+      expect(wrapper.find('.alert').length).to.equal(1)
+    })
+
+    it('does not render the Link component', () => {
+      expect(wrapper.find('Link').length).to.equal(0)
+    })
+  })
+})

--- a/tests/components/Completion.test.js
+++ b/tests/components/Completion.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Completion from '../../app/js/components/Completion'
+
+describe('<Completion />', () => {
+  it('renders the component', () => {
+    const wrapper = shallow(<Completion />)
+    expect(wrapper.find('.tooltip').length).to.equal(1)
+  })
+})

--- a/tests/components/HomeButton.test.js
+++ b/tests/components/HomeButton.test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import HomeButton from '../../app/js/components/HomeButton'
+
+describe('<HomeButton />', () => {
+  it('renders the component', () => {
+    const wrapper = shallow(<HomeButton />)
+    expect(wrapper.find('.btn-home-button').length).to.equal(1)
+    expect(wrapper.find('Link').length).to.equal(1)
+  })
+})

--- a/tests/components/PageHeader.test.js
+++ b/tests/components/PageHeader.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import PageHeader from '../../app/js/components/PageHeader'
+
+describe('<PageHeader />', () => {
+  let wrapper
+  const props = {
+    title: 'title',
+    subtitle: 'subtitle'
+  }
+
+  before(() => {
+    wrapper = shallow(<PageHeader {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('.page-header').length).to.equal(1)
+  })
+
+  it('renders the proper title text', () => {
+    expect(wrapper.find('.h1-modern').text()).to.contain('title')
+  })
+
+  it('renders the proper subtitle text', () => {
+    expect(wrapper.find('.p-r-1').text()).to.contain('subtitle')
+  })
+})

--- a/tests/components/SaveButton.test.js
+++ b/tests/components/SaveButton.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import SaveButton from '../../app/js/components/SaveButton'
+
+describe('<SaveButton />', () => {
+  let onSaveSpy
+  let wrapper
+
+  before(() => {
+    const props = {
+      onSave: onSaveSpy
+    }
+
+    wrapper = shallow(<SaveButton {...props} />)
+  })
+
+  it('renders the save button', () => {
+    expect(wrapper.find('.btn-primary').length).to.equal(1)
+    expect(wrapper.find('.btn-primary').text()).to.contain('Save')
+  })
+
+  it('renders the saving button onClick', () => {
+    wrapper.find('.btn-primary').simulate('click')
+    expect(wrapper.find('.btn-success').length).to.equal(1)
+    expect(wrapper.find('.btn-success').text()).to.contain('Saving...')
+    return expect(wrapper.state('profileJustSaved')).to.equal.true
+  })
+})

--- a/tests/components/SupportButton.test.js
+++ b/tests/components/SupportButton.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import SupportButton from '../../app/js/components/SupportButton'
+
+describe('<SupportButton />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      onClick: sinon.spy()
+    }
+
+    wrapper = shallow(<SupportButton {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('.support-floater').length).to.equal(1)
+  })
+
+  it('calls onClick prop function', () => {
+    wrapper.find('.support-floater').simulate('click')
+    return expect(props.onClick.called).to.be.true
+  })
+})

--- a/tests/components/TrustLevelFooter.test.js
+++ b/tests/components/TrustLevelFooter.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import TrustLevelFooter from '../../app/js/components/TrustLevelFooter'
+
+describe('<TrustLevelFooter />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      onClick: sinon.spy(),
+      maxTrustLevel: 10,
+      trustLevel: 5
+    }
+
+    wrapper = shallow(<TrustLevelFooter {...props} />)
+  })
+
+  it('renders the footer', () => {
+    expect(wrapper.find('.footer').length).to.equal(1)
+  })
+
+  it('calls onClick prop function', () => {
+    wrapper.find('.footer').simulate('click')
+    return expect(props.onClick.called).to.be.true
+  })
+})

--- a/tests/profiles/components/AdvancedSidebar.test.js
+++ b/tests/profiles/components/AdvancedSidebar.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import AdvancedSidebar from '../../../app/js/profiles/components/AdvancedSidebar';
+
+describe('AdvancedSidebar', () => {
+  let props;
+  let wrapper;
+
+  before(() => {
+    props = {
+      activeTab: 'zone-file',
+      name: 'tab-1'
+    }
+
+    wrapper = shallow(<AdvancedSidebar {...props} />)
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('.list-group').length).to.equal(1)
+  })
+
+  it('has an active tab', () => {
+    expect(wrapper.find('.active').length).to.equal(1)
+  })
+
+  it('renders two Link Components', () => {
+    expect(wrapper.find('Link').length).to.equal(2)
+  })
+})

--- a/tests/welcome/components/ConfirmIdentityKeyView.test.js
+++ b/tests/welcome/components/ConfirmIdentityKeyView.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import ConfirmIdentityKeyView from '../../../app/js/welcome/components/ConfirmIdentityKeyView'
+
+describe('<ConfirmIdentityKeyView />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      confirmIdentityKeyPhrase: sinon.spy(),
+      showPreviousView: sinon.spy()
+    }
+    wrapper = shallow(<ConfirmIdentityKeyView {...props} />)
+  })
+  it('renders the component', () => {
+    expect(wrapper.find('.modal-heading').length).to.equal(1)
+  })
+
+  it('renders the InputGroup', () => {
+    expect(wrapper.find('InputGroup').length).to.equal(1)
+  })
+
+  it('renders button', () => {
+    expect(wrapper.find('button').length).to.equal(1)
+  })
+
+  it('calls showPreviousView on Back click', () => {
+    wrapper.find('a').simulate('click')
+    return expect(props.showPreviousView.called).to.be.true
+  })
+})

--- a/tests/welcome/components/CreateIdentityView.test.js
+++ b/tests/welcome/components/CreateIdentityView.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import CreateIdentityView from '../../../app/js/welcome/components/CreateIdentityView'
+
+describe('<CreateIdentityView />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      showNextView: sinon.spy()
+    }
+    wrapper = shallow(<CreateIdentityView {...props} />)
+  })
+  it('renders the component', () => {
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').length).to.equal(1)
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').text()).to.contain(
+      'Blockstack has no 3rd parties: a keychain on your device gives you access'
+    )
+  })
+
+  it('renders the img tag', () => {
+    expect(wrapper.find('img').length).to.equal(1)
+  })
+
+  it('renders the button', () => {
+    expect(wrapper.find('button').length).to.equal(1)
+  })
+
+  it('calls showNextView on Back click', () => {
+    wrapper.find('button').simulate('click')
+    return expect(props.showNextView.called).to.be.true
+  })
+})

--- a/tests/welcome/components/DataControlView.test.js
+++ b/tests/welcome/components/DataControlView.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import DataControlView from '../../../app/js/welcome/components/DataControlView'
+
+describe('<DataControlView />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      showNextView: sinon.spy()
+    }
+    wrapper = shallow(<DataControlView {...props} />)
+  })
+  it('renders the component', () => {
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').length).to.equal(1)
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').text()).to.contain(
+      'On Blockstack you’ll find apps that give you control over your data'
+    )
+  })
+
+  it('renders the button', () => {
+    expect(wrapper.find('button').length).to.equal(1)
+  })
+
+  it('calls showNextView on Back click', () => {
+    wrapper.find('button').simulate('click')
+    return expect(props.showNextView.called).to.be.true
+  })
+})

--- a/tests/welcome/components/EnterEmailView.test.js
+++ b/tests/welcome/components/EnterEmailView.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { EnterEmailView } from '../../../app/js/welcome/components/EnterEmailView'
+
+describe('<EnterEmailView />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      emailNotifications: sinon.spy(),
+      skipEmailBackup: sinon.spy()
+    }
+    wrapper = shallow(<EnterEmailView {...props} />)
+  })
+  it('renders the component', () => {
+    expect(wrapper.find('.modal-heading').length).to.equal(1)
+    expect(wrapper.find('.modal-heading').text()).to.contain('Enter your email address')
+  })
+
+  it('renders the InputGroup', () => {
+    expect(wrapper.find('InputGroup').length).to.equal(1)
+  })
+
+  it('renders button', () => {
+    expect(wrapper.find('button').length).to.equal(1)
+  })
+
+  it('changes the state of email on input change', () => {
+    wrapper.instance().onValueChange({
+      target: { name: 'email', value: 'new-input' }
+    })
+
+    expect(wrapper.state('email')).to.contain('new-input')
+  })
+})

--- a/tests/welcome/components/LandingView.test.js
+++ b/tests/welcome/components/LandingView.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import LandingView from '../../../app/js/welcome/components/LandingView'
+
+describe('<LandingView />', () => {
+  describe('webAppBuild is true', () => {
+    let wrapper
+    let props
+
+    before(() => {
+      props = {
+        showNewInternetView: sinon.spy(),
+        showRestoreView: sinon.spy(),
+        webAppBuild: true
+      }
+      wrapper = shallow(<LandingView {...props} />)
+    })
+
+    it('renders the component', () => {
+      expect(wrapper.find('img.m-b-20').length).to.equal(1)
+    })
+
+    it('renders the webAppBuild', () => {
+      expect(wrapper.find('h3').text()).to.contain(
+        'Welcome to the Blockstack Browser.'
+      )
+      expect(wrapper.find('p').text()).to.contain(
+        'Join the new'
+      )
+    })
+  })
+
+  describe('webAppBuild is false', () => {
+    let wrapper
+    let props
+
+    before(() => {
+      props = {
+        showNewInternetView: sinon.spy(),
+        showRestoreView: sinon.spy(),
+        webAppBuild: false
+      }
+      wrapper = shallow(<LandingView {...props} />)
+    })
+
+    it('renders the component', () => {
+      console.log(wrapper.debug())
+      expect(wrapper.find('img.m-b-20').length).to.equal(1)
+    })
+
+    it('renders the non-webAppBuild', () => {
+      expect(wrapper.find('button').text()).to.contain(
+        'Get Started'
+      )
+      expect(wrapper.find('a').text()).to.contain(
+        'Restore an existing keychain'
+      )
+    })
+
+    it('calls showRestoreView when click the a tag', () => {
+      wrapper.find('a').simulate('click')
+      return expect(props.showRestoreView.called).to.equal.true
+    })
+  })
+})

--- a/tests/welcome/components/NewInternetView.test.js
+++ b/tests/welcome/components/NewInternetView.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import NewInternetView from '../../../app/js/welcome/components/NewInternetView'
+
+describe('<NewInternetView />', () => {
+  let wrapper
+  let props
+
+  before(() => {
+    props = {
+      showNextView: sinon.spy()
+    }
+    wrapper = shallow(<NewInternetView {...props} />)
+  })
+  it('renders the component', () => {
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').length).to.equal(1)
+    expect(wrapper.find('.modal-heading.m-t-15.p-b-10').text()).to.contain(
+      'Blockstack is a new internet designed for freedom & security'
+    )
+  })
+
+  it('renders the button', () => {
+    expect(wrapper.find('button').length).to.equal(1)
+  })
+
+  it('calls showNextView on Continue click', () => {
+    wrapper.find('button').simulate('click')
+    return expect(props.showNextView.called).to.be.true
+  })
+})


### PR DESCRIPTION
- Added a bunch of component tests for blockstack-browser.
- Due to eslint I added a return statement for a couple of expectations.
- Statements: 4% Improvement
- Functions: 6% Improvement

Previous:
![screenshot of iterm2 4-18-18 4-33-35 pm](https://user-images.githubusercontent.com/8473884/38972284-84386728-436d-11e8-9286-9101b1bead1d.png)

Now:
<img width="308" alt="screenshot of iterm2 4-19-18 1-00-33 am" src="https://user-images.githubusercontent.com/8473884/38972292-89941e06-436d-11e8-9986-96b8e6a491d8.png">

