### PR TITLE
Migration fixes

### DIFF
--- a/app/js/common/index.js
+++ b/app/js/common/index.js
@@ -14,7 +14,8 @@ const formatAppManifest = manifest => {
 const asyncLocalStorage = {
   setItem: (key, value) =>
     Promise.resolve().then(() => localStorage.setItem(key, value)),
-  getItem: key => Promise.resolve().then(() => localStorage.getItem(key))
+  getItem: key => Promise.resolve().then(() => localStorage.getItem(key)),
+  removeItem: key => Promise.resolve().then(() => localStorage.removeItem(key))
 }
 
 export { formatAppManifest, asyncLocalStorage }

--- a/app/js/update/views/initial.js
+++ b/app/js/update/views/initial.js
@@ -122,8 +122,18 @@ class PasswordView extends React.Component {
 
     const props = {
       title: {
-        children: 'Enter your password',
-        variant: 'h2'
+        children: 'We have updated the browser.',
+        variant: 'h2',
+        subtitle: {
+          light: true,
+          padding: '15px 0 0 0',
+          children: (
+            <React.Fragment>
+              Please enter your password to migrate your data to the new
+              version.
+            </React.Fragment>
+          )
+        }
       },
       content: {
         grow: 0,

--- a/app/js/update/views/no-update.js
+++ b/app/js/update/views/no-update.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 class NoUpdate extends React.Component {
   componentDidMount() {
-    setTimeout(() => this.props.finish(), 3000)
+    setTimeout(() => this.props.finish(), 3500)
   }
 
   render() {
@@ -31,7 +31,10 @@ class NoUpdate extends React.Component {
           {
             label: <React.Fragment>Continue</React.Fragment>,
             primary: true,
-            onClick: () => finish()
+            onClick: () => finish(),
+            loading: true,
+            placeholder: 'Redirecting...',
+            disabled: true
           }
         ]
       }

--- a/app/js/update/views/success.js
+++ b/app/js/update/views/success.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 class Success extends React.Component {
   componentDidMount() {
-    setTimeout(() => this.props.finish(), 8000)
+    setTimeout(() => this.props.finish(), 3500)
   }
 
   render() {
@@ -31,7 +31,10 @@ class Success extends React.Component {
           {
             label: <React.Fragment>Continue</React.Fragment>,
             primary: true,
-            onClick: () => finish()
+            onClick: () => finish(),
+            loading: true,
+            placeholder: 'Redirecting...',
+            disabled: true
           }
         ]
       }


### PR DESCRIPTION
This updates the copy for the update page, along with adding a fix for if a user has an old state but no account. It will just wipe the persisted store and the next time an action fires, it will be re-saved as the latest state.

cc @yknl 