### PR TITLE
Add a clear auth route for apps

### DIFF
--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -7,21 +7,21 @@ export default class ClearAuthPage extends PureComponent {
   }
 
   cancel() {
-    window.close()
+    window.history.back()
   }
 
   render() {
     return (
       <div className="container-fluid">
-        <h3 className="p-t-20">Clear Application Data</h3>
+        <h3 className="p-t-20">Sign Out</h3>
         <p>
           <i>
-            Are you sure you want to do this? It cannot be undone.
+            Erase your keychain and settings so you can create a new one or restore another keychain.
           </i>
         </p>
         <div className="m-t-40">
           <button className="btn btn-danger btn-block" onClick={this.clearData}>
-            Clear Data
+            Confirm
           </button>
         </div>
         <div className="m-t-10">

--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react'
+import { withRouter } from 'react-router'
 
-export default class ClearAuthPage extends PureComponent {
-  clearData() {
+class ClearAuthPage extends PureComponent {
+  clearData = () => {
     localStorage.clear()
-    window.location = 'myblockstackapp://?authCleared=1'
+    window.location = `${this.props.location.query.protocol}://?authCleared=1`
   }
 
-  cancel() {
-    window.history.back()
+  cancel = () => {
+    window.location = `${this.props.location.query.protocol}://?authCleared=0`
   }
 
   render() {
@@ -33,3 +34,5 @@ export default class ClearAuthPage extends PureComponent {
     )
   }
 }
+
+export default withRouter(ClearAuthPage)

--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -4,11 +4,11 @@ import { withRouter } from 'react-router'
 class ClearAuthPage extends PureComponent {
   clearData = () => {
     localStorage.clear()
-    window.location = `${this.props.location.query.protocol}://?authCleared=1`
+    window.location = `${this.props.location.query.redirect_uri}://?authCleared=1`
   }
 
   cancel = () => {
-    window.location = `${this.props.location.query.protocol}://?authCleared=0`
+    window.location = `${this.props.location.query.redirect_uri}://?authCleared=0`
   }
 
   render() {

--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -1,0 +1,35 @@
+import React, { PureComponent } from 'react'
+
+export default class ClearAuthPage extends PureComponent {
+  clearData() {
+    localStorage.clear()
+    window.location = 'myblockstackapp://?authCleared=1'
+  }
+
+  cancel() {
+    window.close()
+  }
+
+  render() {
+    return (
+      <div className="container-fluid">
+        <h3 className="p-t-20">Clear Application Data</h3>
+        <p>
+          <i>
+            Are you sure you want to do this? It cannot be undone.
+          </i>
+        </p>
+        <div className="m-t-40">
+          <button className="btn btn-danger btn-block" onClick={this.clearData}>
+            Clear Data
+          </button>
+        </div>
+        <div className="m-t-10">
+          <button className="btn btn-tertiary btn-block" onClick={this.cancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/js/routes.js
+++ b/app/js/routes.js
@@ -35,7 +35,8 @@ import ReceivePage from './wallet/ReceivePage'
 import SendPage from './wallet/SendPage'
 import SendCorePage from './wallet/SendCorePage'
 
-import NewAuthPage from './auth/index'
+import NewAuthPage from './auth'
+import ClearAuthPage from './clear-auth'
 
 import SignUpPage from './sign-up'
 import SeedPage from './seed'
@@ -108,6 +109,7 @@ export default (
     <Route path="/sign-in" component={SignInPage} />
     <Route path="/sign-in/*" component={SignInPage} />
     <Route path="/seed" component={SeedPage} />
+    <Route path="/clear-auth" component={ClearAuthPage} />
     <Route path="/*" component={NotFoundPage} />
   </Router>
 )


### PR DESCRIPTION
Closes #1502. Adds a simple route to `/clear-auth` that presents 2 buttons, either clear local storage or cancel. The page doesn't use the app template as the user shouldn't really do anything from this other than clear storage.

<img width="180" alt="screen shot 2018-07-03 at 5 10 34 pm" src="https://user-images.githubusercontent.com/649992/42244788-59c5ebe8-7ee4-11e8-8381-1d0323af038b.png">
