### PR TITLE
Show spinner in onboarding loader

### DIFF
--- a/app/js/components/ui/components/shell/index.js
+++ b/app/js/components/ui/components/shell/index.js
@@ -6,6 +6,7 @@ import { Buttons } from '@components/ui/components/button'
 const Loading = styled(animated.div)`
   position: absolute;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   background: white;

--- a/app/js/components/ui/containers/shell.js
+++ b/app/js/components/ui/containers/shell.js
@@ -6,6 +6,7 @@ import { FormContainer } from '@components/ui/containers/form'
 import { withShellContext } from '@blockstack/ui/common/withOnboardingState'
 import { Spring } from 'react-spring'
 import { Spinner } from '@components/ui/components/spinner'
+import { colors } from '@components/styled/theme'
 import PropTypes from 'prop-types'
 
 const Shell = props => <StyledShell {...props} />
@@ -43,8 +44,10 @@ const Loading = ({ message = 'Loading...', children, ...rest }) => (
   <Spring native from={{ opacity: 0 }} to={{ opacity: 1 }}>
     {styles => (
       <StyledShell.Loading {...rest} style={styles}>
-        <Spinner />
-        {children || message}
+        <Spinner color={colors.blue} size={42} stroke={3} />
+        <div className="m-t-20">
+          {children || message}
+        </div>
       </StyledShell.Loading>
     )}
   </Spring>


### PR DESCRIPTION
It looks like this was supposed to be working before, but it was a white loader on white background. Adjust the loader so it sits on top of the content instead of besides it, make it bigger, and make it blue. Closes #1500.

![loader](https://user-images.githubusercontent.com/649992/42349564-2b415fe4-807b-11e8-94ba-b75cc6d4e1fe.gif)