### PR TITLE
Allow free subdomains outside of onboarding

### DIFF
--- a/app/js/profiles/components/registration/RegistrationSearchView.js
+++ b/app/js/profiles/components/registration/RegistrationSearchView.js
@@ -79,13 +79,8 @@ class RegistrationSearchView extends Component {
 
   componentDidMount() {
     logger.trace('componentDidMount')
-    this.props.refreshCoreWalletBalance(this.props.balanceUrl,
-      this.props.api.coreAPIPassword)
-    if (this.props.localIdentities.map(x => x.usernamePending).includes(true)) {
-      this.updateAlert(
-        'danger', 'You have a pending name registration. Starting a new registration' +
-          ' may interfere with that registration\'s transactions.')
-    }
+    const { refreshCoreWalletBalance, balanceUrl, api } = this.props
+    refreshCoreWalletBalance(balanceUrl, api.coreAPIPassword)
   }
 
 

--- a/app/js/profiles/components/registration/RegistrationSearchView.js
+++ b/app/js/profiles/components/registration/RegistrationSearchView.js
@@ -51,13 +51,14 @@ class RegistrationSearchView extends Component {
 
   constructor(props) {
     super(props)
-    const availableDomains = Object.assign({},
-      {
-        id: {
-          registerUrl: this.props.api.registerUrl
-        }
-      }) // ,
-      // this.props.api.subdomains)
+    const availableDomains = {
+      // ...this.props.api.subdomains,
+      // Hardcode which subdomains we allow fow now
+      id: {
+        registerUrl: this.props.api.registerUrl
+      },
+      'id.blockstack': this.props.api.subdomains['id.blockstack']
+    }
     const nameSuffixes = Object.keys(availableDomains)
 
     this.state = {

--- a/app/js/profiles/components/registration/RegistrationSelectView.js
+++ b/app/js/profiles/components/registration/RegistrationSelectView.js
@@ -116,6 +116,18 @@ class AddUsernameSelectPage extends Component {
     logger.trace('componentDidMount')
     this.props.refreshBalances(this.props.insightUrl, this.props.addresses,
           this.props.api.coreAPIPassword)
+
+    // Only consider top level domains for showing the alert
+    if (!isSubdomain(this.props.routeParams.name)) {
+      const hasPendingReg = this.props.localIdentities
+        .filter(ident => ident.usernamePending)
+        .reduce((prev, ident) => prev || !isSubdomain(ident.username), false)
+      if (hasPendingReg) {
+        this.updateAlert('danger', 'You have a pending name registration. ' +
+          'Starting a new registration may interfere with that ' +
+          'registration’s transactions.')
+      }
+    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Adds a check against the subdomain when registering a name outside of onboarding. Looks identical to the gif in #1204. Closes #1499.