### PR TITLE
Fix onboarding input visual alignment

### DIFF
--- a/app/js/components/ui/components/form/index.js
+++ b/app/js/components/ui/components/form/index.js
@@ -6,7 +6,7 @@ import { Form as FormikForm } from 'formik'
 const shakeAnimation = keyframes`${shake}`
 
 const Input = styled.input`
-  padding: 10px 0;
+  padding: 5px 0 15px;
   margin-top: 5px;
   border: none;
   outline: none;
@@ -64,16 +64,24 @@ const InputOverlay = styled.div`
 `
 
 const Label = styled.label`
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
   display: flex;
   align-items: center;
-  transform: translate3d(0, 0, 0);
   padding-right: 10px;
   line-height: 1.4;
+  transform: translate3d(0, 0, 0);
+  transform-origin: center left;
+  color: rgba(39, 15, 52);
+  ${trans};
+
   /* default state */
   ${Input}:not(:focus) ~ &,
   ${Textarea}:not(:focus) ~ & {
-    top: 10px;
-    color: rgba(39, 15, 52, 0.4);
+    transform: translateY(10px);
+    opacity: 0.4;
   }
 
   /* focus / content state */
@@ -81,24 +89,18 @@ const Label = styled.label`
   ${Input}:not(:placeholder-shown) ~ &,
   ${Textarea}:focus ~ &,
   ${Textarea}:not(:placeholder-shown) ~ & {
-    top: -15px;
-    font-size: 12px;
+    transform: translateY(-17px) scale(0.85);
     font-weight: 500;
-    color: rgba(39, 15, 52, 1);
+    opacity: 1;
   }
 
   ${Textarea}:not(:focus) ~ & {
-    left: 10px !important;
+    left: 10px;
   }
   ${Textarea}:focus ~ &,
   ${Textarea}:not(:placeholder-shown) ~ & {
-    top: -22px;
-    left: 0 !important;
+    transform: translateY(-22px) scale(0.85);
   }
-  position: absolute;
-  left: 0;
-  pointer-events: none;
-  ${trans};
 `
 
 const HelperMessage = styled.div`

--- a/app/js/components/ui/components/form/index.js
+++ b/app/js/components/ui/components/form/index.js
@@ -6,7 +6,7 @@ import { Form as FormikForm } from 'formik'
 const shakeAnimation = keyframes`${shake}`
 
 const Input = styled.input`
-  padding: 5px 0 15px;
+  padding: 10px 0;
   margin-top: 5px;
   border: none;
   outline: none;
@@ -56,7 +56,7 @@ const Bar = styled.div`
 
 const InputOverlay = styled.div`
   position: absolute;
-  top: 10px;
+  top: 15px;
   color: rgba(39, 15, 52, 0.4);
   right: 0;
   pointer-events: none;
@@ -80,7 +80,7 @@ const Label = styled.label`
   /* default state */
   ${Input}:not(:focus) ~ &,
   ${Textarea}:not(:focus) ~ & {
-    transform: translateY(10px);
+    transform: translateY(15px);
     opacity: 0.4;
   }
 
@@ -95,11 +95,11 @@ const Label = styled.label`
   }
 
   ${Textarea}:not(:focus) ~ & {
-    left: 10px;
+    transform: translateY(10px) translateX(10px);
   }
   ${Textarea}:focus ~ &,
   ${Textarea}:not(:placeholder-shown) ~ & {
-    transform: translateY(-22px) scale(0.85);
+    transform: translateY(-24px) scale(0.85) translateX(0);
   }
 `
 


### PR DESCRIPTION
Closes #1408. This raises the text to match the labels and overlay placements (I raised the input text rather than lowered the `.id.blockstack` text because then it wouldn't have aligned with label text.) 

While I was in the neighborhood, I also converted the labels to animate on opacity and transforms, rather than using font-size, color, and top. This should perform a little better and cause less animation jank.

## Before

<img width="468" alt="screen shot 2018-07-06 at 4 47 06 pm" src="https://user-images.githubusercontent.com/649992/42399621-916cd96c-813c-11e8-9662-123a139ccc96.png">


## After

<img width="468" alt="screen shot 2018-07-06 at 4 47 00 pm" src="https://user-images.githubusercontent.com/649992/42399622-932bb0e8-813c-11e8-97aa-df67377652f7.png">
