### PR TITLE
Subtle error animation in onboarding

### DIFF
--- a/app/js/components/ui/components/form/index.js
+++ b/app/js/components/ui/components/form/index.js
@@ -1,9 +1,16 @@
 import styled, { css, keyframes } from 'styled-components'
 import { trans } from '@ui/common'
 import { spacing } from '@ui/common/constants'
-import { shake } from 'react-animations'
 import { Form as FormikForm } from 'formik'
-const shakeAnimation = keyframes`${shake}`
+const shakeAnimation = keyframes`
+  0% { transform: translateX(-10px); }
+  16% { transform: translateX(8px); }
+  33% { transform: translateX(-6px); }
+  50% { transform: translateX(4px); }
+  66% { transform: translateX(-2px); }
+  83% { transform: translateX(1px); }
+  100% { transform: translateX(0); }
+`
 
 const Input = styled.input`
   padding: 10px 0;
@@ -117,7 +124,7 @@ const Group = styled.div`
     error &&
     css`
       ${InputWrapper} {
-        animation: 0.75s ${shakeAnimation} ease-in-out;
+        animation: 0.6s ${shakeAnimation} ease;
       }
       ${Bar} {
         background: #f67b7b !important;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "query-string": "^4.2.3",
     "react": "^16.4.0",
     "react-addons-css-transition-group": "^15.6.2",
-    "react-animations": "^1.0.0",
     "react-bootstrap": "^0.28.2",
     "react-contextmenu": "^2.8.0",
     "react-copy-to-clipboard": "^5.0.1",


### PR DESCRIPTION
Closes #1364, and removes `react-animations` as a dependency.

## Old

![shake-old](https://user-images.githubusercontent.com/649992/42401329-290575da-8143-11e8-83f0-d6a9c5cbd320.gif)


## New

![shake-new](https://user-images.githubusercontent.com/649992/42401333-2d193378-8143-11e8-80cb-f50ae60e4a71.gif)
