### PR TITLE
Add Noscript Message

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,42 @@
         height: 100%;
         width: 100%;
       }
+
+      noscript {
+        display: flex;
+        position: fixed;
+        align-items: center;
+        flex-direction: column;
+        justify-content: center;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 20px;
+      }
+      noscript h1,
+      noscript p {
+        width: 100%;
+        max-width: 600px;
+        margin: 0 auto;
+      }
+      noscript h1 {
+        margin-bottom: 30px;
+        font-size: 32px;
+      }
+      noscript p {
+        font-size: 18px;
+      }
     </style>
+    <noscript>
+      <h1>You Must Enable Javascript to Continue</h1>
+      <p>
+        The Blockstack Browser requires Javascript to be enabled in order to
+        work. If you are not sure why you are seeing this message, or don't know
+        how to enable Javascript, please visit
+        <a href="https://www.enable-javascript.com/" rel="noopener noreferrer" target="_blank">enable-javascript.com</a>
+        to learn more.
+      </p>
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
Closes #1508. Adds a message using the `<noscript>` tag for users who don't have Javascript enabled. I'm linking out to enable-javascript.com in this message, but if we want to set up our own page for explaining this or use a different resource, let me know.

<img width="1128" alt="screen shot 2018-07-17 at 2 07 46 pm" src="https://user-images.githubusercontent.com/649992/42837085-04eee9e8-89cb-11e8-9091-5cc95baafec7.png">
