### PR TITLE
Show error if manifest.json request fails

### DIFF
--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -48,6 +48,7 @@ import {
   selectPublicKeychain
 } from '@common/store/selectors/account'
 import { formatAppManifest } from '@common'
+import Modal from 'react-modal'
 
 const views = [Initial, LegacyGaia]
 
@@ -100,6 +101,7 @@ class AuthPage extends React.Component {
     corePort: PropTypes.number.isRequired,
     appManifest: PropTypes.object,
     appManifestLoading: PropTypes.bool,
+    appManifestLoadingError: PropTypes.string,
     email: PropTypes.string,
     noCoreSessionToken: PropTypes.func.isRequired,
     addresses: PropTypes.array.isRequired,
@@ -493,8 +495,26 @@ class AuthPage extends React.Component {
   }
 
   render() {
-    const { appManifest, appManifestLoading } = this.props
+    const { appManifest, appManifestLoading, appManifestLoadingError } = this.props
 
+    if (appManifestLoadingError) {
+      return (
+        <React.Fragment>
+          <Modal
+            className="container-fluid"
+            shouldCloseOnOverlayClick={false}
+            isOpen
+          >
+            <div className="alert alert-danger">
+              Failed to fetch information about the app requesting
+              authentication. Please contact the app maintainer to resolve the
+              issue.
+            </div>
+          </Modal>
+          <AppHomeWrapper />
+        </React.Fragment>
+      )
+    }
     if (!appManifest || appManifestLoading) {
       return <React.Fragment> </React.Fragment>
     }


### PR DESCRIPTION
Addresses the issue in blockstack.js: https://github.com/blockstack/blockstack.js/issues/462. Right now manifest.json request failures aren't rendered at all, so a user just sees a white page. This code alone doesn't work, requires this pull request from blockstack.js to work (todo: link to pr.) Looks like this when manifest.json is rejected (Suggestions for better copy? But only devs should really see this, so it's not super important.)

<img width="909" alt="screen shot 2018-07-17 at 5 39 26 pm" src="https://user-images.githubusercontent.com/649992/42846941-61373030-89e8-11e8-9dab-20eacdbab78d.png">