### PR TITLE
Fixing description of key words that was over-corrected

### DIFF
--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -50,7 +50,7 @@ const InitialSignInScreen = ({ next, ...rest }) => {
         <React.Fragment>
           <Type.p>
             Enter your Magic Recovery Code. This code was sent to you when you created your ID. Alternatively,
-            you can supply your Secret Recovery Key. This key is a sequence of words you recorded, for example, "rabbit, pink, ..." 
+            you can supply your Secret Recovery Key. This key is a sequence of words you recorded, for example, "rabbit pink ..." 
           </Type.p>
         </React.Fragment>
       )

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -49,8 +49,8 @@ const InitialSignInScreen = ({ next, ...rest }) => {
       children: (
         <React.Fragment>
           <Type.p>
-            Enter your Magic Recovery Code (we sent it to you when you created your ID)
-            or Secret Recovery Key (those 12 or 24 words you recorded).
+            Enter your Magic Recovery Code. This code was sent to you when you created your ID. Alternatively,
+            you can supply your Secret Recovery Key. This key is a sequence of words you recorded, for example, "rabbit, pink, ..." 
           </Type.p>
         </React.Fragment>
       )


### PR DESCRIPTION
Adding the phrase "(those 12 or 24 words you recorded)" is confusing.  The count is dependent on the code base, originally 24 was the base and then later 12.  The number of words in the code recorded is immaterial to the user as it is now to the system because the underlying bug was fixed.

A better approach is to supply an example and make no mention of the count *as either count is now accepted*. 

Xref:

#1448 
 https://github.com/blockstack/blockstack-ios/issues/23


Signed-off-by: moxiegirl <mary@blockstack.com>