### PR TITLE
Validate Sign-in Recovery Field

### DIFF
--- a/app/js/sign-in/index.js
+++ b/app/js/sign-in/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { validateMnemonic } from 'bip39'
 import { decrypt, isBackupPhraseValid } from '@utils'
 import { browserHistory, withRouter } from 'react-router'
 import { connect } from 'react-redux'
@@ -120,8 +121,7 @@ class SignIn extends React.Component {
 
   backToSignUp = () => browserHistory.push({ pathname: '/sign-up' })
 
-  isKeyEncrypted = key =>
-    !(key.split(' ').length === 12 || key.split(' ').length === 24)
+  isKeyEncrypted = key => !validateMnemonic(key)
 
   validateRecoveryKey = (key, nextView = VIEWS.EMAIL) => {
     if (this.state.key !== key) {

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -2,11 +2,22 @@ import React from 'react'
 import { ShellScreen, Type } from '@blockstack/ui'
 import PropTypes from 'prop-types'
 import Yup from 'yup'
+import { validateMnemonic } from 'bip39'
 
 const validationSchema = Yup.object({
   recoveryKey: Yup.string()
-    .min(8, 'Your key is too short.')
     .required('This is required.')
+    .test('is-valid', 'That’s not a valid recovery key or code', value => {
+      // Raw mnemonic phrase
+      if (validateMnemonic(value)) {
+        return true
+      }
+      // Base64 encoded encrypted phrase
+      if (/[a-zA-Z0-9+/]=$/.test(value)) {
+        return true
+      }
+      return false
+    })
 })
 const InitialSignInScreen = ({ next, ...rest }) => {
   const props = {

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -7,7 +7,7 @@ import { validateMnemonic } from 'bip39'
 const validationSchema = Yup.object({
   recoveryKey: Yup.string()
     .required('This is required.')
-    .test('is-valid', 'That’s not a valid recovery key or code', value => {
+    .test('is-valid', 'That’s not a valid recovery code or key', value => {
       // Raw mnemonic phrase
       if (validateMnemonic(value)) {
         return true


### PR DESCRIPTION
Closes #1533. Validates the field to make sure it's a valid mnemonic phrase or base64 encoded 108 length encrypted phrase. As far as I know, there are no other types of recovery methods.

![recovery-validation](https://user-images.githubusercontent.com/649992/42956083-09c9e502-8b4d-11e8-807d-80e4d55deca3.gif)
