### PR TITLE
Prevent Profile Deletion on Name Registration

### DIFF
--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -139,8 +139,9 @@ function registerName(api, domainName, identity, identityIndex,
                       ownerAddress, keypair, paymentKey = null) {
   logger.trace(`registerName: domainName: ${domainName}`)
   return dispatch => {
-    logger.debug(`Signing a blank default profile for ${domainName}`)
-    const signedProfileTokenData = signProfileForUpload(DEFAULT_PROFILE, keypair)
+    logger.debug(`Signing a new profile for ${domainName}`)
+    const profile = identity.profile || DEFAULT_PROFILE
+    const signedProfileTokenData = signProfileForUpload(profile, keypair)
 
     dispatch(profileUploading())
     logger.trace(`Uploading ${domainName} profile...`)


### PR DESCRIPTION
Closes #1529. Simply signs the new profile token with the existing data when available, rather than using `DEFAULT_PROFILE`.