### PR TITLE
Move Mnemonic Encryption / Decryption to Web Worker

### DIFF
--- a/app/js/account/ChangePasswordPage.js
+++ b/app/js/account/ChangePasswordPage.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 
 import Alert from '@components/Alert'
 import InputGroup from '@components/InputGroup'
+import SimpleButton from '@components/SimpleButton'
 import { AccountActions } from './store/account'
 import { decrypt, encrypt } from '@utils'
 import log4js from 'log4js'
@@ -62,36 +63,46 @@ class ChangePasswordPage extends Component {
 
   reencryptMnemonic() {
     logger.trace('reencryptMnemonic')
+    this.setState({
+      isProcessing: true,
+      alerts: []
+    })
+
     const currentPassword = this.state.currentPassword
     const newPassword = this.state.newPassword
     const newPassword2 = this.state.newPassword2
     const dataBuffer = new Buffer(this.props.encryptedBackupPhrase, 'hex')
+
+    if (newPassword.length < 8) {
+      this.updateAlert('danger', 'New password must be at least 8 characters')
+      this.setState({ isProcessing: false })
+      return
+    } else if (newPassword !== newPassword2) {
+      this.updateAlert('danger', 'New passwords must match')
+      this.setState({ isProcessing: false })
+      return
+    }
+
     logger.debug('Trying to decrypt recovery phrase...')
     decrypt(dataBuffer, currentPassword).then(
       plaintextBuffer => {
         logger.debug('Recovery phrase successfully decrypted')
-        if (newPassword.length < 8) {
-          this.updateAlert('danger', 'New password must be at least 8 characters')
-        } else {
-          if (newPassword !== newPassword2) {
-            this.updateAlert('danger', 'New passwords must match')
-          } else {
-            logger.debug('Trying to re-encrypt recovery phrase with new password...')
-            encrypt(plaintextBuffer, newPassword).then(ciphertextBuffer => {
-              this.props.updateBackupPhrase(ciphertextBuffer.toString('hex'))
-              this.updateAlert('success', 'Password updated!')
-              this.setState({
-                currentPassword: '',
-                newPassword: '',
-                newPassword2: ''
-              })
-            })
-          }
-        }
+        logger.debug('Trying to re-encrypt recovery phrase with new password...')
+        encrypt(plaintextBuffer, newPassword).then(ciphertextBuffer => {
+          this.props.updateBackupPhrase(ciphertextBuffer.toString('hex'))
+          this.updateAlert('success', 'Password updated!')
+          this.setState({
+            currentPassword: '',
+            newPassword: '',
+            newPassword2: '',
+            isProcessing: false
+          })
+        })
       },
       () => {
         logger.error('Invalid password')
         this.updateAlert('danger', 'Incorrect password')
+        this.setState({ isProcessing: false })
       }
     )
   }
@@ -127,9 +138,14 @@ class ChangePasswordPage extends Component {
             onReturnKeyPress={this.reencryptMnemonic}
           />
           <div className="container-fluid m-t-40">
-            <button className="btn btn-primary btn-block" onClick={this.reencryptMnemonic}>
+            <SimpleButton
+              type="primary"
+              onClick={this.reencryptMnemonic}
+              loading={this.state.isProcessing}
+              block
+            >
               Update Password
-            </button>
+            </SimpleButton>
           </div>
         </div>
       </div>

--- a/app/js/components/SimpleButton.js
+++ b/app/js/components/SimpleButton.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router'
+import { Spinner } from '@components/ui/components/spinner'
+
+export default class OldButton extends React.PureComponent {
+  static propTypes = {
+    type: PropTypes.oneOf([
+      'primary',
+      'secondary',
+      'tertiary',
+      'success',
+      'danger',
+      'warning',
+      'info',
+      'light',
+      'dark'
+    ]),
+    size: PropTypes.oneOf(['sm', 'lg']),
+    block: PropTypes.boolean,
+    outline: PropTypes.boolean,
+    pill: PropTypes.boolean,
+    active: PropTypes.boolean,
+    disabled: PropTypes.boolean,
+    loading: PropTypes.boolean,
+    className: PropTypes.string,
+    to: PropTypes.string,
+    children: PropTypes.node.isRequired
+  }
+
+  render() {
+    const { type, size, block, outline, pill, loading, disabled, active, to, className, ...rest } = this.props
+    const isDisabled = disabled || loading
+    const classes = [
+      'btn',
+      size && `btn-${size}`,
+      block && 'btn-block',
+      pill && 'btn-pill',
+      active && 'btn-active'
+    ]
+    if (type) {
+      if (outline) {
+        classes.push(`btn-outline-${type}`)
+      }
+      else {
+        classes.push(`btn-${type}`)
+      }
+    }
+    classes.push(className)
+
+    const classNames = classes.filter(s => !!s).join(' ')
+    const content = loading ? (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+      >
+        {this.props.children}
+        <div style={{ marginLeft: '10px' }}>
+          <Spinner size={18} />
+        </div>
+      </div>
+    ) : this.props.children
+
+    return to ? (
+      <Link to={to} className={classNames} disabled={isDisabled} {...rest}>
+        {content}
+      </Link>
+    ) : (
+      <button className={classNames} disabled={isDisabled} {...rest}>
+        {content}
+      </button>
+    )
+  }
+}

--- a/app/js/utils/encryption-utils.js
+++ b/app/js/utils/encryption-utils.js
@@ -1,117 +1,36 @@
-import bip39 from 'bip39'
-import crypto from 'crypto'
-import triplesec from 'triplesec'
+import EncryptWorker from './workers/encrypt.worker'
+import DecryptWorker from './workers/decrypt.worker'
 
-function normalizeMnemonic(mnemonic) {
-  return bip39.mnemonicToEntropy(mnemonic).toString('hex')
-} 
-
-function denormalizeMnemonic(normalizedMnemonic) {
-  return bip39.entropyToMnemonic(normalizedMnemonic)
-} 
-
-function encryptMnemonic(plaintextBuffer, password) {
-  return Promise.resolve().then(() => {
-    // must be bip39 mnemonic 
-    if (!bip39.validateMnemonic(plaintextBuffer.toString())) {
-      throw new Error('Not a valid bip39 nmemonic')
+function runWorker(WorkerClass, args) {
+  return new Promise((resolve, reject) => {
+    const worker = new WorkerClass()
+    worker.onmessage = ev => {
+      if (ev.data.payload) {
+        resolve(ev.data.payload)
+      }
+      else {
+        reject(new Error(ev.data.error))
+      }
     }
+    worker.onerror = err => {
+      reject(err)
+    }
+    worker.postMessage(args)
 
-    // normalize plaintext to fixed length byte string
-    const plaintextNormalized = Buffer.from(
-      normalizeMnemonic(plaintextBuffer.toString()), 'hex')
-
-    // AES-128-CBC with SHA256 HMAC 
-    const salt = crypto.randomBytes(16)
-    const keysAndIV = crypto.pbkdf2Sync(password, salt, 100000, 48, 'sha512')
-    const encKey = keysAndIV.slice(0, 16)
-    const macKey = keysAndIV.slice(16, 32)
-    const iv = keysAndIV.slice(32, 48)
-
-    const cipher = crypto.createCipheriv('aes-128-cbc', encKey, iv)
-    let cipherText = cipher.update(plaintextNormalized, '', 'hex')
-    cipherText += cipher.final('hex')
-
-    const hmacPayload = Buffer.concat([salt, Buffer.from(cipherText, 'hex')])
-
-    const hmac = crypto.createHmac('sha256', macKey)
-    hmac.write(hmacPayload)
-    const hmacDigest = hmac.digest()
-
-    const payload = Buffer.concat([salt, hmacDigest, Buffer.from(cipherText, 'hex')])
-    return payload
+    // Fallback if worker silently fails (can happen in some browsers)
+    setTimeout(() => {
+      reject(new Error('Worker timed out'))
+    }, 15000)
   })
 }
-
-function decryptMnemonic(dataBuffer, password) {
-  return Promise.resolve().then(() => {
-    const salt = dataBuffer.slice(0, 16)
-    const hmacSig = dataBuffer.slice(16, 48)   // 32 bytes
-    const cipherText = dataBuffer.slice(48)
-    const hmacPayload = Buffer.concat([salt, cipherText])
-
-    const keysAndIV = crypto.pbkdf2Sync(password, salt, 100000, 48, 'sha512')
-    const encKey = keysAndIV.slice(0, 16)
-    const macKey = keysAndIV.slice(16, 32)
-    const iv = keysAndIV.slice(32, 48)
-
-    const decipher = crypto.createDecipheriv('aes-128-cbc', encKey, iv)
-    let plaintext = decipher.update(cipherText, '', 'hex')
-    plaintext += decipher.final('hex')
-
-    const hmac = crypto.createHmac('sha256', macKey)
-    hmac.write(hmacPayload)
-    const hmacDigest = hmac.digest()
-
-    // hash both hmacSig and hmacDigest so string comparison time
-    // is uncorrelated to the ciphertext 
-    const hmacSigHash = crypto.createHash('sha256')
-      .update(hmacSig)
-      .digest()
-      .toString('hex')
-
-    const hmacDigestHash = crypto.createHash('sha256')
-      .update(hmacDigest)
-      .digest()
-      .toString('hex')
-    
-    if (hmacSigHash !== hmacDigestHash) {
-      // not authentic
-      throw new Error('Wrong password (HMAC mismatch)')
-    }
-
-    const mnemonic = denormalizeMnemonic(plaintext)
-    if (!bip39.validateMnemonic(mnemonic)) {
-      throw new Error('Wrong password (invalid plaintext)')
-    }
-
-    return mnemonic
-  })
-}
-
 
 export function encrypt(plaintextBuffer, password) {
-  return encryptMnemonic(plaintextBuffer, password)
+  const mnemonic = plaintextBuffer.toString()
+  return runWorker(EncryptWorker, { mnemonic, password })
 }
 
 export function decrypt(dataBuffer, password) {
-  return decryptMnemonic(dataBuffer, password)
-  .catch(() => // try the old way
-    new Promise((resolve, reject) => {
-      triplesec.decrypt(
-        {
-          key: new Buffer(password),
-          data: dataBuffer
-        },
-        (err, plaintextBuffer) => {
-          if (!err) {
-            resolve(plaintextBuffer)
-          } else {
-            reject(err)
-          }
-        }
-      )
-    })
-  )
+  const encryptedMnemonic = dataBuffer.toString('hex')
+  return runWorker(DecryptWorker, { encryptedMnemonic, password })
+    .then(mnemonic => Buffer.from(mnemonic))
 }
-

--- a/app/js/utils/workers/decrypt.worker.js
+++ b/app/js/utils/workers/decrypt.worker.js
@@ -1,0 +1,93 @@
+import bip39 from 'bip39'
+import crypto from 'crypto'
+import triplesec from 'triplesec'
+
+function denormalizeMnemonic(normalizedMnemonic) {
+  return bip39.entropyToMnemonic(normalizedMnemonic)
+}
+
+function decryptMnemonic(dataBuffer, password) {
+  return Promise.resolve().then(() => {
+    const salt = dataBuffer.slice(0, 16)
+    const hmacSig = dataBuffer.slice(16, 48)   // 32 bytes
+    const cipherText = dataBuffer.slice(48)
+    const hmacPayload = Buffer.concat([salt, cipherText])
+
+    const keysAndIV = crypto.pbkdf2Sync(password, salt, 100000, 48, 'sha512')
+    const encKey = keysAndIV.slice(0, 16)
+    const macKey = keysAndIV.slice(16, 32)
+    const iv = keysAndIV.slice(32, 48)
+
+    const decipher = crypto.createDecipheriv('aes-128-cbc', encKey, iv)
+    let plaintext = decipher.update(cipherText, '', 'hex')
+    plaintext += decipher.final('hex')
+
+    const hmac = crypto.createHmac('sha256', macKey)
+    hmac.write(hmacPayload)
+    const hmacDigest = hmac.digest()
+
+    // hash both hmacSig and hmacDigest so string comparison time
+    // is uncorrelated to the ciphertext
+    const hmacSigHash = crypto.createHash('sha256')
+      .update(hmacSig)
+      .digest()
+      .toString('hex')
+
+    const hmacDigestHash = crypto.createHash('sha256')
+      .update(hmacDigest)
+      .digest()
+      .toString('hex')
+
+    if (hmacSigHash !== hmacDigestHash) {
+      // not authentic
+      throw new Error('Wrong password (HMAC mismatch)')
+    }
+
+    const mnemonic = denormalizeMnemonic(plaintext)
+    if (!bip39.validateMnemonic(mnemonic)) {
+      throw new Error('Wrong password (invalid plaintext)')
+    }
+
+    return mnemonic
+  })
+}
+
+function decryptLegacy(dataBuffer, password) {
+  return new Promise((resolve, reject) => {
+    triplesec.decrypt(
+      {
+        key: new Buffer(password),
+        data: dataBuffer
+      },
+      (err, plaintextBuffer) => {
+        if (!err) {
+          resolve(plaintextBuffer)
+        } else {
+          reject(err)
+        }
+      }
+    )
+  })
+}
+
+self.onmessage = async event => {
+  try {
+    const { encryptedMnemonic, password } = event.data
+    const dataBuffer = Buffer.from(encryptedMnemonic, 'hex')
+    let mnemonic
+
+    try {
+      mnemonic = await decryptMnemonic(dataBuffer, password)
+    } catch(err) {
+      mnemonic = await decryptLegacy(dataBuffer, password)
+    }
+
+    self.postMessage({
+      payload: mnemonic.toString()
+    })
+  } catch(err) {
+    self.postMessage({
+      error: err.toString()
+    })
+  }
+}

--- a/app/js/utils/workers/encrypt.worker.js
+++ b/app/js/utils/workers/encrypt.worker.js
@@ -1,0 +1,49 @@
+import bip39 from 'bip39'
+
+function normalizeMnemonic(mnemonic) {
+  return bip39.mnemonicToEntropy(mnemonic).toString('hex')
+}
+
+function encryptMnemonic(mnemonic, password) {
+  // must be bip39 mnemonic
+  if (!bip39.validateMnemonic(mnemonic)) {
+    throw new Error('Not a valid bip39 nmemonic')
+  }
+
+  // normalize plaintext to fixed length byte string
+  const plaintextNormalized = Buffer.from(normalizeMnemonic(mnemonic), 'hex')
+
+  // AES-128-CBC with SHA256 HMAC
+  const salt = crypto.randomBytes(16)
+  const keysAndIV = crypto.pbkdf2Sync(password, salt, 100000, 48, 'sha512')
+  const encKey = keysAndIV.slice(0, 16)
+  const macKey = keysAndIV.slice(16, 32)
+  const iv = keysAndIV.slice(32, 48)
+
+  const cipher = crypto.createCipheriv('aes-128-cbc', encKey, iv)
+  let cipherText = cipher.update(plaintextNormalized, '', 'hex')
+  cipherText += cipher.final('hex')
+
+  const hmacPayload = Buffer.concat([salt, Buffer.from(cipherText, 'hex')])
+
+  const hmac = crypto.createHmac('sha256', macKey)
+  hmac.write(hmacPayload)
+  const hmacDigest = hmac.digest()
+
+  const payload = Buffer.concat([salt, hmacDigest, Buffer.from(cipherText, 'hex')])
+  return payload
+}
+
+self.onmessage = event => {
+  try {
+    const { mnemonic, password } = event.data
+    const encryptedBuffer = encryptMnemonic(mnemonic, password)
+    self.postMessage({
+      payload: encryptedBuffer.toString('hex')
+    })
+  } catch(err) {
+    self.postMessage({
+      error: err.toString()
+    })
+  }
+}

--- a/app/js/utils/workers/encrypt.worker.js
+++ b/app/js/utils/workers/encrypt.worker.js
@@ -1,4 +1,5 @@
 import bip39 from 'bip39'
+import crypto from 'crypto'
 
 function normalizeMnemonic(mnemonic) {
   return bip39.mnemonicToEntropy(mnemonic).toString('hex')

--- a/package-lock.json
+++ b/package-lock.json
@@ -38889,6 +38889,29 @@
         "errno": "~0.1.7"
       }
     },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
+        }
+      }
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "webpack-dev-server": "^3.1.4",
     "webpackbar": "^2.6.1",
     "workbox-webpack-plugin": "^3.3.0",
+    "worker-loader": "2.0.0",
     "yargs": "^3.27.0"
   },
   "keywords": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,10 @@ const isProd = process.env.NODE_ENV === 'production'
 const output = {
   filename: 'js/[name].[hash:8].js',
   chunkFilename: 'js/[name].[hash:8].chunk.js',
-  path: path.resolve(__dirname, 'build')
+  path: path.resolve(__dirname, 'build'),
+  publicPath: '/',
+  // Fix workers & HMR https://github.com/webpack/webpack/issues/6642
+  globalObject: 'self'
 }
 
 /**
@@ -31,6 +34,7 @@ const output = {
 if (isProd) {
   output.path = path.resolve(__dirname, 'build/static')
   output.publicPath = '/static/'
+  output.globalObject = undefined
 }
 
 /**
@@ -123,6 +127,10 @@ module.exports = {
             options: { minimize: true }
           }
         ]
+      },
+      {
+        test: /\.worker\.js$/,
+        use: 'worker-loader'
       }
     ]
   },


### PR DESCRIPTION
Closes #1507. Relies on #1479. Moves mnemonic encryption / decryption to a web worker so that the main thread isn't blocked while it's doing its magic. Also replaces some of the buttons that didn't have any indication of what was going on with buttons that disable and show a loader while they're working. 

It's worth noting that this PR only handles mnemonic en/decryption, and some performance issues still remain, namely with address derivation. However, I wanted to keep this initial PR pretty small to make it easier to review. But we should probably revisit the other crypto-heavy calls and workerize them.

Before:
<img width="573" alt="screen shot 2018-07-19 at 4 21 34 pm" src="https://user-images.githubusercontent.com/649992/42967955-de9e0c50-8b6f-11e8-9e75-8ea7a979152d.png">


After:
<img width="573" alt="screen shot 2018-07-19 at 4 21 09 pm" src="https://user-images.githubusercontent.com/649992/42967966-e344f1e2-8b6f-11e8-82f4-18bf456def09.png">
