### PR TITLE
Add minimum length check for sponsored names 

### DIFF
--- a/app/js/sign-up/views/_username.js
+++ b/app/js/sign-up/views/_username.js
@@ -59,6 +59,20 @@ class UsernameView extends React.Component {
     }
 
     if (values.username !== this.state.username && !noValues) {
+
+      const MIN_USERNAME_LENGTH = 8
+      const validLength = values.username.length >= MIN_USERNAME_LENGTH
+
+      const minLengthErrorMessage = `Username must be at least ${8} characters.`
+
+      if (!validLength) {
+        this.setState({
+          status: 'error'
+        })
+        errors.username = minLengthErrorMessage
+        throw errors
+      }
+
       const invalidChars = values.username.match(/\W+/g)
 
       if (invalidChars) {


### PR DESCRIPTION
This is the pull request corresponding the length check in the subdomain registrar: https://github.com/blockstack/subdomain-registrar/pull/16

It checks to make sure usernames are at least 8 characters.
