### PR TITLE
Fix 404 Page Position

### DIFF
--- a/app/js/errors/NotFoundPage.js
+++ b/app/js/errors/NotFoundPage.js
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Link } from 'react-router'
+import App from '../App'
 
 import Navbar from '@components/Navbar'
 
-const NotFoundPage = (props) =>
-(
-  <div className="app-wrap-profiles">
+const NotFoundPage = (props) => (
+  <App>
     <Navbar />
-      {props.children}
+    {props.children}
     <div className="container-fluid m-t-50">
       <div className="row">
         <div className="col-12">
@@ -21,7 +21,7 @@ const NotFoundPage = (props) =>
         </div>
       </div>
     </div>
-  </div>
+  </App>
 )
 
 NotFoundPage.propTypes = {


### PR DESCRIPTION
Closes #1503. Adds the `<App>` component to the NotFoundPage so that it renders correctly.

<img width="706" alt="screen shot 2018-07-26 at 10 56 47 am" src="https://user-images.githubusercontent.com/649992/43270290-b2a8f094-90c2-11e8-8e49-e7c4999165a0.png">
