### PR TITLE
Add more component tests

### DIFF
--- a/test/components/Image.test.js
+++ b/test/components/Image.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Image from '../../app/js/components/Image'
+
+describe('<Image />', () => {
+  describe('renders the component', () =>{
+    const props = {
+      src: 'test.jpg',
+      fallbackSrc: 'fallback.jpg',
+      retinaSupport: true
+    }
+
+    const wrapper = shallow(<Image {...props} />)
+
+    it('uses an img tag', () => {
+      expect(wrapper.find('img').exists()).to.equal(true)  
+    })
+    
+    it('has a src attribute', () => {
+      expect(wrapper.find('[src="test.jpg"]').exists()).to.equal(true)
+    })
+
+    /* TODO: Add test for retina support (may require change to
+     object under test) */
+
+    it('uses fallbackSrc on error', () => {
+      wrapper.find('img').simulate('error')
+      expect(wrapper.find('[src="fallback.jpg"]').exists()).to.equal(true)
+    })
+
+  })
+})
+

--- a/test/components/InputGroup.test.js
+++ b/test/components/InputGroup.test.js
@@ -31,11 +31,12 @@ describe('<InputGroup />', () => {
     })
 
     it('names the input tag', () => {
-      expect(wrapper.find('input[name="input-group-test"]'))
+      expect(wrapper.find('input[name="input-group-test"]').exists()).to.equal(true)
     })
 
     it('creates a placeholder', () => {
-      expect(wrapper.find('input[placeholder="Zero Cost Marginal Society"]'))
+      expect(wrapper.find(
+            'input[placeholder="Zero Cost Marginal Society"]').exists()).to.equal(true)
     })
 
     it('creates an accessory icon', () => {

--- a/test/components/InputGroup.test.js
+++ b/test/components/InputGroup.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import InputGroup from '../../app/js/components/InputGroup'
+
+describe('<InputGroup />', () => {
+  describe('renders the component', () => {
+    const props = {
+      name: 'input-group-test',
+      label: 'Equality',
+      data: {
+        test: 'Blockchain Revolution'
+      },
+      centerText: true,
+      placeholder: 'Zero Cost Marginal Society',
+      accessoryIcon: true,
+      accessoryIconClass: 'eloquent-javascript'
+    }
+    const wrapper = shallow(<InputGroup {...props} />)
+
+    it('creates a div with text-center in the class name', () => {
+      expect(wrapper.find('.text-center').exists()).to.equal(true)
+    })
+
+    it('creates a label tag', () => {
+      expect(wrapper.find('label').text()).to.equal('Equality')
+    })
+
+    it('creates an input tag', () => {
+      expect(wrapper.find('input').exists()).to.equal(true)
+    })
+
+    it('names the input tag', () => {
+      expect(wrapper.find('input[name="input-group-test"]'))
+    })
+
+    it('creates a placeholder', () => {
+      expect(wrapper.find('input[placeholder="Zero Cost Marginal Society"]'))
+    })
+
+    it('creates an accessory icon', () => {
+      expect(wrapper.find('span.eloquent-javascript').exists()).to.equal(true)
+    })
+  })   
+})

--- a/test/components/InputGroupSecondary.test.js
+++ b/test/components/InputGroupSecondary.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import InputGroupSecondary from '../../app/js/components/InputGroupSecondary'
+
+describe('<InputGroupSecondary />', () => {
+  describe('renders the component with an input tag', () => {
+    const props = {
+      label: 'The DevOps Handbook',
+      placeholder: 'Designing Data Intensive Applications',
+      name: 'The Republic'
+    }
+
+    const wrapper = shallow(<InputGroupSecondary {...props} />)
+
+    it('creates a label tag', () => {
+      expect(wrapper.find('label').text()).to.equal('The DevOps Handbook')
+    })
+
+    it('creates placeholder text', () => {
+      expect(wrapper.find('[placeholder="Designing Data Intensive Applications"]').exists()).to.equal(true)
+    })
+
+    it('names the input tag', () => {
+      expect(wrapper.find('input[name="The Republic"]').exists()).to.equal(true)
+    })
+  })
+
+  describe('renders the component with a textarea tag', () => {
+    const props = {
+      textarea: true,
+      textareaRows: 4,
+      label: ''
+    }
+
+    const wrapper = shallow(<InputGroupSecondary {...props} />)
+
+    it('uses a textarea tag', () => {
+      expect(wrapper.find('textarea').exists()).to.equal(true)
+    })
+
+    it('sets the number of rows', () => {
+      expect(wrapper.find('[rows=4]').exists()).to.equal(true)
+    })
+  })
+})

--- a/test/components/Navbar.test.js
+++ b/test/components/Navbar.test.js
@@ -12,99 +12,48 @@ describe('<Navbar />', () => {
     })
   })
 
-  describe('renders the component with active home tab', () => {
-    const props = {
-      activeTab: 'home'
-    } 
+  const tabDetails = [
+    {
+      name: 'home',
+      activeIcon: '/images/icon-nav-home-hover.svg',
+      regularIcon: '/images/icon-nav-home.svg'}, 
+    {
+      name:'settings',
+      activeIcon: '/images/icon-nav-settings-hover.svg',
+      regularIcon: '/images/icon-nav-settings.svg'}, 
+    {
+      name:'wallet',
+      activeIcon: '/images/icon-nav-wallet-hover.svg',
+      regularIcon: '/images/icon-nav-wallet.svg' }, 
+    {
+      name: 'profile', 
+      prop: 'avatar',
+      activeIcon: '/images/icon-nav-profile-hover.svg',
+      regularIcon: '/images/icon-nav-profile.svg'
+    }]
 
-    const wrapper = shallow(<Navbar {...props} />)
+  tabDetails.forEach((tab) => {
+    describe(
+    `renders the component with active ${tab.name} tab`, () => {
+      const props = {
+        activeTab: tab.prop || tab.name
+      } 
 
-    it('uses the active home tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-home-hover.svg"]').exists()).to.equal(true)
+      const wrapper = shallow(<Navbar {...props} />)
+
+      it(`uses the active ${tab.name} tab icon`, () => {
+        expect(wrapper.find(`img[src="${tab.activeIcon}"]`)
+        .exists()).to.equal(true)
+      })
+
+      const tabs = tabDetails.filter(temp => temp.name !== tab.name)      
+
+      tabs.forEach((innerLoopTab) => {
+        it(`uses the regular ${innerLoopTab.name} tab icon`, () => {
+          expect(wrapper.find(`img[src="${innerLoopTab.regularIcon}"]`)
+          .exists()).to.equal(true)
+        })
+      })
     })
-
-    it('uses the regular settings tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular wallet tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular profile tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
-    })
-  })
-
-  describe('renders the component with active settings tab', () => {
-    const props = {
-      activeTab: 'settings'
-    } 
-
-    const wrapper = shallow(<Navbar {...props} />)
-
-    it('uses the regular home tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the active settings tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-settings-hover.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular wallet tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular profile tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
-    })
-  })
-
-  describe('renders the component with active wallet tab', () => {
-    const props = {
-      activeTab: 'wallet'
-    } 
-
-    const wrapper = shallow(<Navbar {...props} />)
-
-    it('uses the regular home tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular settings tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the active wallet tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-wallet-hover.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular profile tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
-    })
-  })
-
-  describe('renders the component with active profile tab', () => {
-    const props = {
-      activeTab: 'avatar'
-    } 
-
-    const wrapper = shallow(<Navbar {...props} />)
-
-    it('uses the regular home tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular settings tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the regular wallet tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
-    })
-
-    it('uses the active profile tab icon', () => {
-      expect(wrapper.find('img[src="/images/icon-nav-profile-hover.svg"]').exists()).to.equal(true)
-    })
-  })
+  }) 
 })

--- a/test/components/Navbar.test.js
+++ b/test/components/Navbar.test.js
@@ -1,0 +1,110 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Navbar from '../../app/js/components/Navbar'
+
+describe('<Navbar />', () => {
+  describe('renders the component', () => {
+    const wrapper = shallow(<Navbar />)
+
+    it('creates four <Link /> tags', () => {
+      expect(wrapper.find('Link')).to.have.length(4)
+    })
+  })
+
+  describe('renders the component with active home tab', () => {
+    const props = {
+      activeTab: 'home'
+    } 
+
+    const wrapper = shallow(<Navbar {...props} />)
+
+    it('uses the active home tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-home-hover.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular settings tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular wallet tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular profile tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
+    })
+  })
+
+  describe('renders the component with active settings tab', () => {
+    const props = {
+      activeTab: 'settings'
+    } 
+
+    const wrapper = shallow(<Navbar {...props} />)
+
+    it('uses the regular home tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the active settings tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-settings-hover.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular wallet tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular profile tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
+    })
+  })
+
+  describe('renders the component with active wallet tab', () => {
+    const props = {
+      activeTab: 'wallet'
+    } 
+
+    const wrapper = shallow(<Navbar {...props} />)
+
+    it('uses the regular home tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular settings tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the active wallet tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-wallet-hover.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular profile tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-profile.svg"]').exists()).to.equal(true)
+    })
+  })
+
+  describe('renders the component with active profile tab', () => {
+    const props = {
+      activeTab: 'avatar'
+    } 
+
+    const wrapper = shallow(<Navbar {...props} />)
+
+    it('uses the regular home tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-home.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular settings tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-settings.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the regular wallet tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-wallet.svg"]').exists()).to.equal(true)
+    })
+
+    it('uses the active profile tab icon', () => {
+      expect(wrapper.find('img[src="/images/icon-nav-profile-hover.svg"]').exists()).to.equal(true)
+    })
+  })
+})

--- a/test/components/Navigation.test.js
+++ b/test/components/Navigation.test.js
@@ -16,7 +16,7 @@ describe('<Navigation />', () => {
     })
 
     it('includes the previous label', () => {
-      expect(wrapper.childAt(0).childAt(1).text()).to.contain('Back')
+      expect(wrapper.html()).to.contain('Back')
     })
   })
 
@@ -29,7 +29,7 @@ describe('<Navigation />', () => {
     const wrapper = shallow(<Navigation {...props} />)
 
     it('includes the supplied label', () => {
-      expect(wrapper.childAt(0).childAt(1).text()).to.contain('Previous Page')
+      expect(wrapper.html()).to.contain('Previous Page')
     })
   })
 })

--- a/test/components/Navigation.test.js
+++ b/test/components/Navigation.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Navigation from '../../app/js/components/Navigation'
+
+describe('<Navigation />', () => {
+  describe('renders the component', () => {
+    const props = {
+      previous() {}
+    }  
+  
+    const wrapper = shallow(<Navigation {...props} />)
+
+    it('uses a ChevronLeftIcon', () => {
+      expect(wrapper.find('ChevronLeftIcon').exists()).to.equal(true)
+    })
+
+    it('includes the previous label', () => {
+      expect(wrapper.childAt(0).childAt(1).text()).to.contain('Back')
+    })
+  })
+
+  describe('renders the component with a label', () => {
+    const props = {
+      previous() {},
+      previousLabel: 'Previous Page'
+    }
+
+    const wrapper = shallow(<Navigation {...props} />)
+
+    it('includes the supplied label', () => {
+      expect(wrapper.childAt(0).childAt(1).text()).to.contain('Previous Page')
+    })
+  })
+})


### PR DESCRIPTION
This PR includes more unit tests for app/js/components. It helps with issue #368. 

The tests are based on existing code, testing some of the ways that components are rendered when supplied with different props. They typically check if the render function produces particular elements with specific attributes and text nodes. Very happy to discuss ways in which the tests may be improved :hammer: :grin:  

New test suites are added for components that were previously untested.