### PR TITLE
Update non-use css class in NotFoundPage.js

### DIFF
--- a/app/js/errors/NotFoundPage.js
+++ b/app/js/errors/NotFoundPage.js
@@ -6,7 +6,7 @@ import Navbar from '@components/Navbar'
 
 const NotFoundPage = (props) =>
 (
-  <div className="app-wrap-profiles">
+  <div className="body-main">
     <Navbar />
       {props.children}
     <div className="container-fluid m-t-50">


### PR DESCRIPTION
Notice that 404, Page Not Found warning is mostly covered under "Navbar"*, did quick check and found out "app-wrap-profiles" is not being defined. If I understand correctly, using "body-main" would be proper in this one.

* as seen in Safari ![image](https://user-images.githubusercontent.com/602540/43627023-1cec56d4-9727-11e8-848f-d656632293d2.png)
