### PR TITLE
Fix events firing in dev

### DIFF
--- a/app/js/utils/server-utils.js
+++ b/app/js/utils/server-utils.js
@@ -70,7 +70,7 @@ export function trackEvent(event: string, properties: Object) {
 
   // Prevent noisy stats from development testing behavior
   // TODO: process.env.NODE_ENV, when that's fixed. Use this for now.
-  if (window.location.port === 3000) {
+  if (window.location.port === '3000') {
     console.info(`Event track fired: '${event}'`)
     return
   }


### PR DESCRIPTION
Small fix for a last minute change in #1554, `window.location.port` is a string, not a number, and this was a strict equality check.