### PR TITLE
Fix identity restore in onboarding

### DIFF
--- a/app/js/sign-in/index.js
+++ b/app/js/sign-in/index.js
@@ -198,21 +198,24 @@ class SignIn extends React.Component {
 
   restoreAccount = () => {
     console.log('Restoring account!')
-    const { api, identityAddresses, refreshIdentities, updateEmail } = this.props
-    this.setState({ loading: true })
-    this.createAccount()
-    .then(
-      () => {
-        refreshIdentities(api, identityAddresses)
-        updateEmail(this.state.email)
-      },
-      err => console.error(err)
-    )
-    .then(() => this.updateView(VIEWS.SUCCESS))
-    .catch(() => {
-      this.setState({
-        loading: false,
-        restoreError: 'There was an error loading your account.'
+    const { refreshIdentities, updateEmail } = this.props
+    this.setState({
+      loading: true
+    }, () => {
+      this.createAccount()
+      .then(
+        () => {
+          refreshIdentities(this.props.api, this.props.identityAddresses)
+          updateEmail(this.state.email)
+        },
+        err => console.error(err)
+      )
+      .then(() => this.updateView(VIEWS.SUCCESS))
+      .catch(() => {
+        this.setState({
+          loading: false,
+          restoreError: 'There was an error loading your account.'
+        })
       })
     })
   }


### PR DESCRIPTION
Small fixes for not showing your name during onboarding, uses the up-to-date props from `createAccount` call to send to `refreshIdentities` instead of using the stale props from before `createAccount` finished. Also moves the calls into a `setState` callback so that it properly shows the loader before it starts.

<img width="483" alt="screen shot 2018-08-03 at 10 18 40 am" src="https://user-images.githubusercontent.com/649992/43647995-2f365530-9707-11e8-91cb-1c195d7e155b.png">
