### PR TITLE
Show Loader / Wait for Identity Resolve at Sign In

### DIFF
--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -372,6 +372,7 @@ function refreshIdentities(
                                 trustLevel
                               )
                             )
+                            resolve()
                           })
                           .catch(error => {
                             logger.error(

--- a/app/js/sign-in/index.js
+++ b/app/js/sign-in/index.js
@@ -202,27 +202,29 @@ class SignIn extends React.Component {
     this.setState({
       loading: true
     }, () => {
-      this.createAccount()
-      .then(
-        () => {
-          refreshIdentities(this.props.api, this.props.identityAddresses)
-          updateEmail(this.state.email)
-        },
-        err => console.error(err)
-      )
-      .then(() => this.updateView(VIEWS.SUCCESS))
-      .catch(() => {
-        this.setState({
-          loading: false,
-          restoreError: 'There was an error loading your account.'
+      // Quick setTimeout just to get the loader going before we lock up the
+      // browser with decryption. TODO: Remove this when it's workerized.
+      setTimeout(() => {
+        this.createAccount()
+        .then(() => refreshIdentities(this.props.api, this.props.identityAddresses))
+        .then(() => updateEmail(this.state.email))
+        .then(() => this.updateView(VIEWS.SUCCESS))
+        .catch(() => {
+          this.setState({
+            loading: false,
+            restoreError: 'There was an error loading your account.'
+          })
         })
-      })
+      }, 300)
     })
   }
 
 
   updateView = view => {
-    this.setState({ view })
+    this.setState({
+      view,
+      loading: false
+    })
     this.trackViewEvent(view)
   }
 

--- a/app/js/sign-in/views/_email.js
+++ b/app/js/sign-in/views/_email.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ShellScreen } from '@blockstack/ui'
+import { ShellScreen, Shell } from '@blockstack/ui'
 import Yup from 'yup'
 import PropTypes from 'prop-types'
 
@@ -48,19 +48,27 @@ class EmailView extends React.Component {
                 label: 'Next',
                 primary: true,
                 type: 'submit',
-                icon: 'ArrowRightIcon'
+                icon: 'ArrowRightIcon',
+                loading: this.props.loading
               }
             ]
           }
         }
       }
     }
-    return <ShellScreen {...rest} {...props} />
+
+    return (
+      <React.Fragment>
+        {this.props.loading && <Shell.Loading message="Restoring your account..." />}
+        <ShellScreen {...rest} {...props} />
+      </React.Fragment>
+    )
   }
 }
 EmailView.propTypes = {
   email: PropTypes.string,
   updateValue: PropTypes.func,
-  next: PropTypes.func
+  next: PropTypes.func,
+  loading: PropTypes.bool
 }
 export default EmailView


### PR DESCRIPTION
Closes #1570. Correctly shows the a loader while decrypting and fetching identity info during sign in. Waits to go to the next screen until identity fetch is complete, to prevent flash of "Nameless user."

### Steps to test

* Reset your browser
* Go through account recovery / sign in process
* When you submit your email, confirm you see a loader
* When the process is complete, confirm your identity is recovered correctly 

### See it in action

![recovery-loader](https://user-images.githubusercontent.com/649992/43731485-aa5d2186-997c-11e8-993e-0b20aaa812c7.gif)
