### PR TITLE
More IDs copy changes

### DIFF
--- a/app/js/profiles/AllProfilesPage.js
+++ b/app/js/profiles/AllProfilesPage.js
@@ -145,7 +145,7 @@ class AllProfilesPage extends Component {
           className="container-fluid"
         >
           <form onSubmit={this.createNewProfile}>
-            <h3 className="modal-heading">Enter your password to create a new Blockstack ID</h3>
+            <h3 className="modal-heading">Enter your password to add another Blockstack ID</h3>
             <div>
               {createProfileError ?
                 <Alert key="1" message="Incorrect password" status="danger" />
@@ -168,9 +168,9 @@ class AllProfilesPage extends Component {
               disabled={this.props.isProcessing}
             >
               {this.props.isProcessing ?
-                <span>Creating...</span>
+                <span>Processing...</span>
                 :
-                <span>Create new ID</span>
+                <span>Add another ID</span>
               }
             </button>
           </form>
@@ -217,9 +217,16 @@ class AllProfilesPage extends Component {
                 <button
                   className="btn btn-primary"
                   onClick={this.openPasswordPrompt}
-                >Create new ID
+                >
+                  Add another ID
                 </button>
               </div>
+            </div>
+            <div className="row m-t-20">
+              <p className="col form-text text-muted">
+                Have you recovered and are missing IDs? Just add them
+                back by using the "Add another ID" for each ID.
+              </p>
             </div>
           </div>
         </div>

--- a/app/js/sign-in/views/_success.js
+++ b/app/js/sign-in/views/_success.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ShellScreen, Type, UserAvatar } from '@blockstack/ui'
 import PropTypes from 'prop-types'
+import { Link } from 'react-router'
 
 const messages = {
   namelessUser: (
@@ -70,6 +71,10 @@ class Success extends React.Component {
               <Type.p>
                 Welcome back to the New Internet. Your account has successfully
                 been restored on this device.
+              </Type.p>
+              <Type.p>
+                Have additional IDs? You can re-add them from the{' '}
+                <Link to="/profiles/i/all">"More IDs" page</Link>.
               </Type.p>
               {username === '?' ? (
                 <React.Fragment>


### PR DESCRIPTION
Closes #1577. Adds some additional copy to the end of sign in and on the "More IDs" page that explains how to recover additional IDs that are missing.

<img width="600" alt="screen shot 2018-08-06 at 4 45 11 pm" src="https://user-images.githubusercontent.com/649992/43740059-2d325106-9998-11e8-9807-7af79d1316e7.png">

<img width="350" alt="screen shot 2018-08-06 at 4 45 41 pm" src="https://user-images.githubusercontent.com/649992/43740061-2ef9ff5c-9998-11e8-82da-c9bcbd64a3c5.png">
