### PR TITLE
Fix Enzyme Tests w/ Webpack

### DIFF
--- a/app/js/components/Navbar.js
+++ b/app/js/components/Navbar.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link } from 'react-router'
 
-/* eslint-disable */
-const icons = {
+/* eslint-disable global-require */
+export const ICONS = {
   homeNav: require('@images/icon-nav-home.svg'),
   homeNavActive: require('@images/icon-nav-home-hover.svg'),
   walletNav: require('@images/icon-nav-wallet.svg'),
@@ -13,7 +13,8 @@ const icons = {
   settingsNav: require('@images/icon-nav-settings.svg'),
   settingsNavActive: require('@images/icon-nav-settings-hover.svg')
 }
-/* eslint-enable */
+/* eslint-enable global-require */
+
 class Navbar extends Component {
   static propTypes = {
     activeTab: PropTypes.string
@@ -72,33 +73,33 @@ class Navbar extends Component {
 
   settingsNavIconImage() {
     if (this.props.activeTab === 'settings' || this.state.settingsTabHover) {
-      return icons.settingsNavActive
+      return ICONS.settingsNavActive
     } else {
-      return icons.settingsNav
+      return ICONS.settingsNav
     }
   }
 
   homeNavIconImage() {
     if (this.props.activeTab === 'home' || this.state.homeTabHover) {
-      return icons.homeNavActive
+      return ICONS.homeNavActive
     } else {
-      return icons.homeNav
+      return ICONS.homeNav
     }
   }
 
   walletNavIconImage() {
     if (this.props.activeTab === 'wallet' || this.state.walletTabHover) {
-      return icons.walletNavActive
+      return ICONS.walletNavActive
     } else {
-      return icons.walletNav
+      return ICONS.walletNav
     }
   }
 
   avatarNavIconImage() {
     if (this.props.activeTab === 'avatar' || this.state.avatarTabHover) {
-      return icons.avatarNavActive
+      return ICONS.avatarNavActive
     } else {
-      return icons.avatarNav
+      return ICONS.avatarNav
     }
   }
 

--- a/test/components/Navbar.test.js
+++ b/test/components/Navbar.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { expect } from 'chai'
 import { shallow } from 'enzyme'
-import Navbar from '../../app/js/components/Navbar'
+import Navbar, { ICONS } from '../../app/js/components/Navbar'
 
 describe('<Navbar />', () => {
   describe('renders the component', () => {
@@ -15,21 +15,24 @@ describe('<Navbar />', () => {
   const tabDetails = [
     {
       name: 'home',
-      activeIcon: '/images/icon-nav-home-hover.svg',
-      regularIcon: '/images/icon-nav-home.svg'}, 
+      activeIcon: ICONS.homeNavActive,
+      regularIcon: ICONS.homeNav
+    },
     {
       name:'settings',
-      activeIcon: '/images/icon-nav-settings-hover.svg',
-      regularIcon: '/images/icon-nav-settings.svg'}, 
+      activeIcon: ICONS.settingsNavActive,
+      regularIcon: ICONS.settingsNav
+    },
     {
       name:'wallet',
-      activeIcon: '/images/icon-nav-wallet-hover.svg',
-      regularIcon: '/images/icon-nav-wallet.svg' }, 
+      activeIcon: ICONS.walletNavActive,
+      regularIcon: ICONS.walletNav
+    },
     {
-      name: 'profile', 
+      name: 'profile',
       prop: 'avatar',
-      activeIcon: '/images/icon-nav-profile-hover.svg',
-      regularIcon: '/images/icon-nav-profile.svg'
+      activeIcon: ICONS.avatarNavActive,
+      regularIcon: ICONS.avatarNav
     }]
 
   tabDetails.forEach((tab) => {
@@ -37,7 +40,7 @@ describe('<Navbar />', () => {
     `renders the component with active ${tab.name} tab`, () => {
       const props = {
         activeTab: tab.prop || tab.name
-      } 
+      }
 
       const wrapper = shallow(<Navbar {...props} />)
 
@@ -46,7 +49,7 @@ describe('<Navbar />', () => {
         .exists()).to.equal(true)
       })
 
-      const tabs = tabDetails.filter(temp => temp.name !== tab.name)      
+      const tabs = tabDetails.filter(temp => temp.name !== tab.name)
 
       tabs.forEach((innerLoopTab) => {
         it(`uses the regular ${innerLoopTab.name} tab icon`, () => {
@@ -55,5 +58,5 @@ describe('<Navbar />', () => {
         })
       })
     })
-  }) 
+  })
 })


### PR DESCRIPTION
Some tests from #1561 broke when #1479 merged in, because webpack images requires have extra stuff appended to them. This makes the test use the same variables as the navbar component.