### PR TITLE
Do input cleanup, make a util function for it, added tests.

### DIFF
--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -2,22 +2,14 @@ import React from 'react'
 import { ShellScreen, Type } from '@blockstack/ui'
 import PropTypes from 'prop-types'
 import Yup from 'yup'
-import { validateMnemonic } from 'bip39'
+import { validateAndCleanRecoveryInput } from '@utils/encryption-utils'
 
 const validationSchema = Yup.object({
   recoveryKey: Yup.string()
     .required('This is required.')
-    .test('is-valid', 'That’s not a valid recovery code or key', value => {
-      // Raw mnemonic phrase
-      if (validateMnemonic(value)) {
-        return true
-      }
-      // Base64 encoded encrypted phrase
-      if (/[a-zA-Z0-9+/]=$/.test(value)) {
-        return true
-      }
-      return false
-    })
+    .test('is-valid', 'That’s not a valid recovery code or key', value =>
+      validateAndCleanRecoveryInput(value).isValid
+    )
 })
 const InitialSignInScreen = ({ next, ...rest }) => {
   const props = {
@@ -30,7 +22,7 @@ const InitialSignInScreen = ({ next, ...rest }) => {
         validationSchema,
         initialValues: { recoveryKey: '' },
         onSubmit: values => {
-          next(values.recoveryKey)
+          next(validateAndCleanRecoveryInput(values.recoveryKey).cleaned)
         },
         fields: [
           {
@@ -61,7 +53,7 @@ const InitialSignInScreen = ({ next, ...rest }) => {
         <React.Fragment>
           <Type.p>
             Enter your Magic Recovery Code. This code was sent to you when you created your ID. Alternatively,
-            you can supply your Secret Recovery Key. This key is a sequence of words you recorded, for example, "rabbit pink ..." 
+            you can supply your Secret Recovery Key. This key is a sequence of words you recorded, for example, "rabbit pink ..."
           </Type.p>
         </React.Fragment>
       )

--- a/test/utils/encryption-utils.test.js
+++ b/test/utils/encryption-utils.test.js
@@ -1,4 +1,9 @@
-import { encrypt, decrypt } from '../../app/js/utils/encryption-utils'
+import {
+  encrypt,
+  decrypt,
+  validateAndCleanRecoveryInput,
+  RECOVERY_TYPE
+} from '../../app/js/utils/encryption-utils'
 
 describe('encryption-utils', () => {
   beforeEach(() => {
@@ -26,7 +31,7 @@ describe('encryption-utils', () => {
 
   describe('decrypt legacy', () => {
     it('should decrypt legacy encryption', () => {
-      const legacyCiphertext = '1c94d7de0000000304d583f007c71e6e5fef354c046e8c64b1adebd6904dcb' + 
+      const legacyCiphertext = '1c94d7de0000000304d583f007c71e6e5fef354c046e8c64b1adebd6904dcb' +
         '007a1222f07313643873455ab2a3ab3819e99d518cc7d33c18bde02494aa74efc35a8970b2007b2fc715f' +
         '6067cee27f5c92d020b1806b0444994aab80050a6732131d2947a51bacb3952fb9286124b3c2b3196ff7e' +
         'dce66dee0dbd9eb59558e0044bddb3a78f48a66cf8d78bb46bb472bd2d5ec420c831fc384293252459524' +
@@ -40,6 +45,81 @@ describe('encryption-utils', () => {
           assert(plaintextBuffer)
           assert.equal(plaintextBuffer.toString(), phrase)
         })
+    })
+  })
+
+  describe('validateAndCleanRecoveryInput', () => {
+    const mnemonic = 'opera way alley phrase agree rug hip lyrics link outer inch pigeon'
+    const encrypted = 'p8KwuKW3R9amIkHJKCTNpEMBZVJ/QSfgH1TVSRBRF5bXYHkm57DlnSoW' +
+      '0aqkJ27A59ljcR5NkNw2isDiGSeaixCKhbOQHtgmXr2pmqZb7xI='
+
+    function assertCleanAndValid(input, cleaned, type) {
+      const result = validateAndCleanRecoveryInput(input)
+      assert(result.isValid === true, `result.isValid should be true, is ${result.isValid}`)
+      assert(result.cleaned === cleaned, `result.cleaned should be ${cleaned}, is ${input}`)
+      assert(result.type === type, `result.type should be '${type}'`)
+    }
+
+    function assertInvalid(input) {
+      const result = validateAndCleanRecoveryInput(input)
+      console.log(result)
+      assert(result.isValid === false, `result.isValid should be false, is '${result.isValid}'`)
+    }
+
+    // Mnemonic phrases
+    it('Should find a 12 word mnemonic phrase valid', () => {
+      assertCleanAndValid(mnemonic, mnemonic, RECOVERY_TYPE.MNEMONIC)
+    })
+
+    it('Should clean a dash-delimited mnemonic phrase and find it valid', () => {
+      const dashMnemonic = mnemonic.replace(' ', '-')
+      assertCleanAndValid(dashMnemonic, mnemonic, RECOVERY_TYPE.MNEMONIC)
+    })
+
+    it('Should clean an underscore-delimited mnemonic phrase and find it valid', () => {
+      const dashMnemonic = mnemonic.replace(' ', '_')
+      assertCleanAndValid(dashMnemonic, mnemonic, RECOVERY_TYPE.MNEMONIC)
+    })
+
+    it('Should clean a mnemonic phrase with extra space and find it valid', () => {
+      const whitespaceMnemonic = ` ${mnemonic}
+      `;
+      assertCleanAndValid(whitespaceMnemonic, mnemonic, RECOVERY_TYPE.MNEMONIC)
+    })
+
+    it('Should clean an all caps mnemonic phrase and find it valid', () => {
+      const uppercaseMnemonic = mnemonic.toUpperCase()
+      assertCleanAndValid(uppercaseMnemonic, mnemonic, RECOVERY_TYPE.MNEMONIC)
+    })
+
+    it('Should find a mnemonic that isn’t %3 words long invalid', () => {
+      const shortMnemonic = 'opera way alley phrase agree rug hip lyrics link outer inch'
+      assertInvalid(shortMnemonic)
+    })
+
+    it('Should find a mnemonic that includes incorrect words to be invalid', () => {
+      const wrongWordMnemonic = 'blockstackiscool way alley phrase agree rug hip lyrics link outer inch pigeon'
+      assertInvalid(wrongWordMnemonic)
+    })
+
+    // Encrypted keys
+    it('Should find an encrypted key valid', () => {
+      assertCleanAndValid(encrypted, encrypted, RECOVERY_TYPE.ENCRYPTED)
+    })
+
+    it('Should find an encrypted key with whitespace valid', () => {
+      const whitespaceEncrypted = `
+        p8KwuKW3R9amIkHJKCTNpEMBZVJ
+        /QSfgH1TVSRBRF5bXYHkm57DlnS
+        oW0aqkJ27A59ljcR5NkNw2isDiG
+        SeaixCKhbOQHtgmXr2pmqZb7xI=
+      `
+      assertCleanAndValid(whitespaceEncrypted, encrypted, RECOVERY_TYPE.ENCRYPTED)
+    })
+
+    it('Should find an encrypted key with special characters invalid', () => {
+      const invalidCharacter = `!${encrypted}`
+      assertInvalid(invalidCharacter)
     })
   })
 })


### PR DESCRIPTION
Closes #1602. Adds a bunch of cleanup for potentially invalid recovery codes. Adds testing for all of those cases. See #1602 for examples of some of the stuff that should work now.

### Steps to Test

* Reset your browser, and recover an existing ID
* Add some spaces / linebreaks to the front / back of either recovery method, confirm it works
* Add some line breaks to the middle of either recovery method, confirm it works
* Add some special characters between words in a mnemonic phrase, confirm it works
* Enter an invalid mnemonic phrase, confirm it still tells you its invalid
* Enter an invalid encrypted recovery key, confirm it still tells you its invalid