### PR TITLE
Source Maps + Debugging in Production

### DIFF
--- a/app/js/logger.js
+++ b/app/js/logger.js
@@ -1,23 +1,15 @@
 const isDev = process.env.NODE_ENV === 'development'
-// const isTesting = process.env.NODE_ENV === 'test'
-
-console.log(`############################################################# isDev = ${isDev}`)
+const isDebug = typeof location !== 'undefined' && location.search.includes('debug')
 
 const logger = {
   configure: () => null,
   info: () => null,
   getLogger: log => ({
-    info: message => (isDev ? console.info(log, message) : null),
-    trace: message => (isDev ? console.trace(log, message) : null),
-    error: message => (isDev ? console.error(log, message) : null),
-    debug: message => (isDev ? console.debug(log, message) : null),
-    log: message => (isDev ? console.log(log, message) : null)
-    // info: message => !isTesting && console.info(log, message),
-    // trace: message => !isTesting && console.trace(log, message),
-    // error: message => !isTesting && console.error(log, message),
-    // debug: message => !isTesting && console.debug(log, message),
-    // log: message => !isTesting && console.log(log, message)
-
+    info: message => (isDev || isDebug ? console.info(log, message) : null),
+    trace: message => (isDev || isDebug ? console.trace(log, message) : null),
+    error: message => (isDev || isDebug ? console.error(log, message) : null),
+    debug: message => (isDev || isDebug ? console.debug(log, message) : null),
+    log: message => (isDev || isDebug ? console.log(log, message) : null)
   })
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ if (isProd) {
  */
 module.exports = {
   mode: isProd ? 'production' : 'development',
-  devtool: !isProd ? 'cheap-module-source-map' : false,
+  devtool: !isProd ? 'cheap-module-source-map' : 'source-map',
   entry: {
     main: ['./app/js/index.js']
   },


### PR DESCRIPTION
Closes #1609. Adds regular source maps to production. These have no impact on build size, and only download when you open dev tools. As an added bonus, I've also added the ability to get console debugging in production as well, just put `debug` anywhere in your search query and you’ll get it for the remainder of the session, e.g.
```
localhost:8888/?debug
```
or
```
localhost:8888/auth?authRequest=...&debug
```