### PR TITLE
Fix auth with non-standard profile locations

### DIFF
--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { AuthActions } from './store/auth'
 import { decodeToken } from 'jsontokens'
+import { parseZoneFile } from 'zone-file'
 import {
   makeAuthResponse,
   getAuthRequestFromURL,
@@ -215,8 +216,9 @@ class AuthPage extends React.Component {
       let profileUrlPromise
 
       if (identity.zoneFile && identity.zoneFile.length > 0) {
+        const zoneFileJson = parseZoneFile(identity.zoneFile)
         const profileUrlFromZonefile = getTokenFileUrlFromZoneFile(
-          identity.zoneFile
+          zoneFileJson
         )
         if (
           profileUrlFromZonefile !== null &&


### PR DESCRIPTION
This issue #1607 turns out to have been a straight-forward type error -- the call `getTokenFileUrlFromZoneFile` expects a zone file already parsed as JSON.

This is a pretty old bug (probably > 10 months), and would affect every account with an old profile path (I had an old throwaway account that I tested with.)

