### PR TITLE
Improve logging accuracy & display

### DIFF
--- a/app/js/App.js
+++ b/app/js/App.js
@@ -22,7 +22,7 @@ import { hot } from 'react-hot-loader'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('App.js')
+const logger = log4js.getLogger(__filename)
 
 export const BLOCKSTACK_STATE_VERSION_KEY = 'BLOCKSTACK_STATE_VERSION'
 

--- a/app/js/App.js
+++ b/app/js/App.js
@@ -112,7 +112,7 @@ class AppContainer extends Component {
   }
 
   componentWillMount() {
-    logger.trace('componentWillMount')
+    logger.info('componentWillMount')
     const coreAPIPassword = getCoreAPIPasswordFromURL()
     const logServerPort = getLogServerPortFromURL()
     const regTestMode = getRegTestModeFromURL()

--- a/app/js/UpdateStatePage.js
+++ b/app/js/UpdateStatePage.js
@@ -21,7 +21,7 @@ import {
 } from './utils/api-utils'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('UpdateStatePage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/UpdateStatePage.js
+++ b/app/js/UpdateStatePage.js
@@ -76,11 +76,11 @@ class UpdateStatePage extends Component {
   }
 
   componentDidMount() {
-    logger.trace('componentDidMount')
+    logger.info('componentDidMount')
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     const upgradeInProgress = this.state.upgradeInProgress
     const accountCreated = this.props.accountCreated
     const nextAccountCreated = nextProps.accountCreated
@@ -139,7 +139,7 @@ class UpdateStatePage extends Component {
 
 
     upgradeBlockstackState(event) {
-    logger.trace('upgradeBlockstackState')
+    logger.info('upgradeBlockstackState')
     event.preventDefault()
     this.setState({ upgradeInProgress: true })
     //

--- a/app/js/account/ApiSettingsPage.js
+++ b/app/js/account/ApiSettingsPage.js
@@ -8,7 +8,7 @@ import SaveButton from '@components/SaveButton'
 import { SettingsActions } from './store/settings'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('account/ApiSettingsPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/account/ApiSettingsPage.js
+++ b/app/js/account/ApiSettingsPage.js
@@ -36,14 +36,14 @@ export class ApiSettingsPage extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     this.setState({
       api: nextProps.api
     })
   }
 
   onValueChange = (event) => {
-    logger.trace('onValueChange')
+    logger.info('onValueChange')
     const api = { ...this.state.api }
     const newValue = event.target.value
     const key = event.target.name
@@ -62,13 +62,13 @@ export class ApiSettingsPage extends Component {
   }
 
   updateApi = () => {
-    logger.trace('updateApi')
+    logger.info('updateApi')
     const api = this.state.api
     this.props.updateApi(api)
   }
 
   resetApi = () => {
-    logger.trace('resetApi')
+    logger.info('resetApi')
     this.props.resetApi(this.props.api)
   }
 

--- a/app/js/account/BackupAccountPage.js
+++ b/app/js/account/BackupAccountPage.js
@@ -13,7 +13,7 @@ import log4js from 'log4js'
 
 import { AccountActions } from './store/account'
 
-const logger = log4js.getLogger('account/BackupAccountPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/account/BackupAccountPage.js
+++ b/app/js/account/BackupAccountPage.js
@@ -57,14 +57,14 @@ class BackupAccountPage extends Component {
   }
 
   updateAlert(alertStatus, alertMessage) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{ status: alertStatus, message: alertMessage }]
     })
   }
 
   decryptBackupPhrase() {
-    logger.trace('decryptBackupPhrase')
+    logger.info('decryptBackupPhrase')
 
     const password = this.state.password
     const dataBuffer = new Buffer(this.props.encryptedBackupPhrase, 'hex')

--- a/app/js/account/ChangePasswordPage.js
+++ b/app/js/account/ChangePasswordPage.js
@@ -50,7 +50,7 @@ class ChangePasswordPage extends Component {
   }
 
   updateAlert(alertStatus, alertMessage) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [
         {
@@ -62,7 +62,7 @@ class ChangePasswordPage extends Component {
   }
 
   reencryptMnemonic() {
-    logger.trace('reencryptMnemonic')
+    logger.info('reencryptMnemonic')
     this.setState({
       isProcessing: true,
       alerts: []

--- a/app/js/account/ChangePasswordPage.js
+++ b/app/js/account/ChangePasswordPage.js
@@ -10,7 +10,7 @@ import { AccountActions } from './store/account'
 import { decrypt, encrypt } from '@utils'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('account/ChangePasswordPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/account/DeleteAccountPage.js
+++ b/app/js/account/DeleteAccountPage.js
@@ -54,7 +54,7 @@ class DeleteAccountPage extends Component {
   }
 
   updateAlert(alertStatus, alertMessage) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{ status: alertStatus, message: alertMessage }]
     })
@@ -68,7 +68,7 @@ class DeleteAccountPage extends Component {
   }
 
   openModal() {
-    logger.trace('deleteAccount')
+    logger.info('deleteAccount')
     this.setState({ isOpen: true })
   }
 

--- a/app/js/account/DeleteAccountPage.js
+++ b/app/js/account/DeleteAccountPage.js
@@ -8,7 +8,7 @@ import DeleteAccountModal from './components/DeleteAccountModal'
 import { AccountActions } from './store/account'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('account/DeleteAccountPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/account/StorageProvidersPage.js
+++ b/app/js/account/StorageProvidersPage.js
@@ -12,7 +12,7 @@ import { connectToGaiaHub } from './utils/blockstack-inc'
 import { setCoreStorageConfig } from '@utils/api-utils'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('storage/StorageProvidersPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/account/store/account/actions.js
+++ b/app/js/account/store/account/actions.js
@@ -16,7 +16,7 @@ import roundTo from 'round-to'
 import * as types from './types'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('account/store/account/actions.js')
+const logger = log4js.getLogger(__filename)
 
 const doVerifyRecoveryCode = () => dispatch =>
   dispatch({

--- a/app/js/account/store/account/actions.js
+++ b/app/js/account/store/account/actions.js
@@ -137,7 +137,7 @@ function updateViewedRecoveryCode() {
 }
 
 function displayedRecoveryCode() {
-  logger.trace('displayedRecoveryCode')
+  logger.info('displayedRecoveryCode')
   return dispatch => {
     dispatch(updateViewedRecoveryCode())
   }
@@ -181,14 +181,14 @@ function emailNotifications(email, optIn) {
 }
 
 function skipEmailBackup() {
-  logger.trace('skipEmailBackup')
+  logger.info('skipEmailBackup')
   return dispatch => {
     dispatch(promptedForEmail())
   }
 }
 
 function storageIsConnected() {
-  logger.trace('storageConnected')
+  logger.info('storageConnected')
   return dispatch => {
     dispatch(connectedStorage())
   }
@@ -202,7 +202,7 @@ function refreshCoreWalletBalance(addressBalanceUrl, coreAPIPassword) {
       return Promise.resolve()
     }
 
-    logger.trace('refreshCoreWalletBalance: Beginning refresh...')
+    logger.info('refreshCoreWalletBalance: Beginning refresh...')
     logger.debug(
       `refreshCoreWalletBalance: addressBalanceUrl: ${addressBalanceUrl}`
     )
@@ -259,7 +259,7 @@ function withdrawBitcoinClientSide(
 ) {
   return dispatch => {
     if (regTestMode) {
-      logger.trace('Using regtest network')
+      logger.info('Using regtest network')
       config.network = network.defaults.LOCAL_REGTEST
       // browser regtest environment uses 6270
       config.network.blockstackAPIUrl = 'http://localhost:6270'
@@ -273,7 +273,7 @@ function withdrawBitcoinClientSide(
       .makeBitcoinSpend(recipientAddress, paymentKey, amountSatoshis)
       .then(transactionHex => {
         const myNet = config.network
-        logger.trace(`Broadcast btc spend with tx hex: ${transactionHex}`)
+        logger.info(`Broadcast btc spend with tx hex: ${transactionHex}`)
         return myNet.broadcastTransaction(transactionHex)
       })
       .then(() => dispatch(withdrawCoreBalanceSuccess()))
@@ -485,7 +485,7 @@ function incrementIdentityAddressIndex() {
 }
 
 function usedIdentityAddress() {
-  logger.trace('usedIdentityAddress')
+  logger.info('usedIdentityAddress')
   return dispatch => {
     dispatch(incrementIdentityAddressIndex())
   }

--- a/app/js/account/store/settings/actions.js
+++ b/app/js/account/store/settings/actions.js
@@ -9,7 +9,7 @@ import { BLOCKSTACK_INC } from '../../utils'
 import { setCoreStorageConfig } from '@utils/api-utils'
 import AccountActions from '../account/actions'
 
-const logger = log4js.getLogger('account/store/settings/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function updateApi(api) {
   return {

--- a/app/js/account/store/settings/actions.js
+++ b/app/js/account/store/settings/actions.js
@@ -40,7 +40,7 @@ function refreshBtcPrice(btcPriceUrl) {
 }
 
 function resetApi(api) {
-  logger.trace('resetApi')
+  logger.info('resetApi')
   let coreAPIPassword = api.coreAPIPassword
   let gaiaHubConfig = api.gaiaHubConfig
 
@@ -65,7 +65,7 @@ function resetApi(api) {
 
 function connectStorage() {
   return (dispatch, getState) => {
-    logger.trace('connectStorage')
+    logger.info('connectStorage')
     const state = getState()
     const api = selectApi(state)
     let idKeypairs = selectIdentityKeypairs(state)

--- a/app/js/account/utils/blockstack-inc.js
+++ b/app/js/account/utils/blockstack-inc.js
@@ -5,7 +5,7 @@ import { connectToGaiaHub, GaiaHubConfig } from 'blockstack'
 const logger = log4js.getLogger(__filename)
 
 export function redirectToConnectToGaiaHub() {
-  logger.trace('redirectToConnectToGaiaHub')
+  logger.info('redirectToConnectToGaiaHub')
   const port = location.port === '' ? 80 : location.port
   const host = location.hostname
   window.top.location.href = `http://${host}:${port}/account/storage#gaiahub`

--- a/app/js/account/utils/blockstack-inc.js
+++ b/app/js/account/utils/blockstack-inc.js
@@ -2,7 +2,7 @@
 import log4js from 'log4js'
 import { connectToGaiaHub, GaiaHubConfig } from 'blockstack'
 
-const logger = log4js.getLogger('account/utils/blockstack-inc.js')
+const logger = log4js.getLogger(__filename)
 
 export function redirectToConnectToGaiaHub() {
   logger.trace('redirectToConnectToGaiaHub')

--- a/app/js/account/utils/index.js
+++ b/app/js/account/utils/index.js
@@ -7,7 +7,7 @@ import { connectToGaiaHub, uploadToGaiaHub } from 'blockstack'
 import { getTokenFileUrlFromZoneFile } from '@utils/zone-utils'
 
 import log4js from 'log4js'
-const logger = log4js.getLogger('account/utils/index.js')
+const logger = log4js.getLogger(__filename)
 
 export const BLOCKSTACK_INC = 'gaia-hub'
 const DEFAULT_PROFILE_FILE_NAME = 'profile.json'

--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -52,7 +52,7 @@ import Modal from 'react-modal'
 
 const views = [Initial, LegacyGaia]
 
-const logger = log4js.getLogger('auth/components/AuthModal.js')
+const logger = log4js.getLogger(__filename)
 
 const VIEWS = {
   AUTH: 0,

--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -176,7 +176,7 @@ class AuthPage extends React.Component {
         }
       }
 
-      logger.trace('componentWillReceiveProps')
+      logger.info('componentWillReceiveProps')
 
       const coreSessionToken = nextProps.coreSessionTokens[appDomain]
       let decodedCoreSessionToken = null
@@ -377,7 +377,7 @@ class AuthPage extends React.Component {
 
     this.props.clearSessionToken(appDomain)
 
-    logger.trace(
+    logger.info(
       `login(): id index ${this.state.currentIdentityIndex} is logging in`
     )
     this.setState({ responseSent: true })
@@ -467,7 +467,7 @@ class AuthPage extends React.Component {
           )
           return
         } else if (requestingStoreWrite && !needsCoreStorage) {
-          logger.trace(
+          logger.info(
             'login(): app can communicate directly with gaiahub, not setting up core.'
           )
           this.setState({
@@ -475,7 +475,7 @@ class AuthPage extends React.Component {
           })
           this.props.noCoreSessionToken(appDomain)
         } else {
-          logger.trace('login(): No storage access requested.')
+          logger.info('login(): No storage access requested.')
           this.setState({
             noCoreStorage: true
           })

--- a/app/js/auth/store/auth.js
+++ b/app/js/auth/store/auth.js
@@ -74,7 +74,7 @@ function getCoreSessionToken(
   blockchainId
 ) {
   return dispatch => {
-    logger.trace('getCoreSessionToken(): dispatched')
+    logger.info('getCoreSessionToken(): dispatched')
     const deviceId = '0' // Hard code device id until we support multi-device
     getCoreSession(
       coreHost,
@@ -86,7 +86,7 @@ function getCoreSessionToken(
       deviceId
     ).then(
       coreSessionToken => {
-        logger.trace('getCoreSessionToken: generated a token!')
+        logger.info('getCoreSessionToken: generated a token!')
         dispatch(updateCoreSessionToken(appDomain, coreSessionToken))
       },
       error => {
@@ -98,7 +98,7 @@ function getCoreSessionToken(
 
 function noCoreSessionToken(appDomain) {
   return dispatch => {
-    logger.trace('noCoreSessionToken(): dispatched')
+    logger.info('noCoreSessionToken(): dispatched')
     dispatch(updateCoreSessionToken(appDomain, null))
   }
 }

--- a/app/js/auth/store/auth.js
+++ b/app/js/auth/store/auth.js
@@ -4,7 +4,7 @@ import {
 } from 'blockstack'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('auth/store/auth.js')
+const logger = log4js.getLogger(__filename)
 
 const APP_MANIFEST_LOADING = 'auth/APP_MANIFEST_LOADING'
 const APP_MANIFEST_LOADING_ERROR = 'auth/APP_MANIFEST_LOADING_ERROR'

--- a/app/js/auth/utils.js
+++ b/app/js/auth/utils.js
@@ -26,7 +26,7 @@ export function appRequestSupportsDirectHub(requestPayload: Object): boolean {
 }
 
 export function validateScopes(scopes: Array<string>): boolean {
-  logger.trace('validateScopes')
+  logger.info('validateScopes')
 
   if (!scopes) {
     logger.error('validateScopes: no scopes provided')

--- a/app/js/auth/utils.js
+++ b/app/js/auth/utils.js
@@ -3,7 +3,7 @@
 import log4js from 'log4js'
 import { isLaterVersion } from 'blockstack'
 
-const logger = log4js.getLogger('auth/components/util.js')
+const logger = log4js.getLogger(__filename)
 
 
 const VALID_SCOPES = {

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -79,7 +79,7 @@ window.onerror = (messageOrEvent, source, lineno, colno, error) => {
 }
 
 if (process.env.NODE_ENV !== 'production') {
-  logger.trace('NODE_ENV is not production')
+  logger.info('NODE_ENV is not production')
   logger.debug('Enabling React devtools')
   window.React = React
 }

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -30,7 +30,7 @@ configureLogging(
   process.env.NODE_ENV
 )
 
-let logger = log4js.getLogger('index.js')
+let logger = log4js.getLogger(__filename)
 
 
 window.addEventListener('error', event => {

--- a/app/js/logger.js
+++ b/app/js/logger.js
@@ -12,7 +12,7 @@ const logger = {
       showLog && console.info(`%c[${path}]:`, prefixStyle, message)
     ),
     trace: message => (
-      showLog && console.info(`%c[${path}]:`, prefixStyle, message)
+      showLog && console.trace(`%c[${path}]:`, prefixStyle, message)
     ),
     error: message => (
       showLog && console.error(`%c[${path}]:`, prefixStyle, message)

--- a/app/js/logger.js
+++ b/app/js/logger.js
@@ -1,15 +1,31 @@
 const isDev = process.env.NODE_ENV === 'development'
 const isDebug = typeof location !== 'undefined' && location.search.includes('debug')
+const showLog = isDev || isDebug
+
+const prefixStyle = 'color: #AAA;'
 
 const logger = {
   configure: () => null,
   info: () => null,
-  getLogger: log => ({
-    info: message => (isDev || isDebug ? console.info(log, message) : null),
-    trace: message => (isDev || isDebug ? console.trace(log, message) : null),
-    error: message => (isDev || isDebug ? console.error(log, message) : null),
-    debug: message => (isDev || isDebug ? console.debug(log, message) : null),
-    log: message => (isDev || isDebug ? console.log(log, message) : null)
+  getLogger: path => ({
+    info: message => (
+      showLog && console.info(`%c[${path}]:`, prefixStyle, message)
+    ),
+    trace: message => (
+      showLog && console.info(`%c[${path}]:`, prefixStyle, message)
+    ),
+    error: message => (
+      showLog && console.error(`%c[${path}]:`, prefixStyle, message)
+    ),
+    warn: message => (
+      showLog && console.warn(`%c[${path}]:`, prefixStyle, message)
+    ),
+    debug: message => (
+      showLog && console.debug(`%c[${path}]:`, prefixStyle, message)
+    ),
+    log: message => (
+      showLog && console.log(`%c[${path}]:`, prefixStyle, message)
+    )
   })
 }
 

--- a/app/js/profiles/AllProfilesPage.js
+++ b/app/js/profiles/AllProfilesPage.js
@@ -13,7 +13,7 @@ import { AccountActions }  from '../account/store/account'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/AllProfilesPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/profiles/AllProfilesPage.js
+++ b/app/js/profiles/AllProfilesPage.js
@@ -59,14 +59,14 @@ class AllProfilesPage extends Component {
   }
 
   componentWillMount() {
-    logger.trace('componentWillMount')
+    logger.info('componentWillMount')
     this.props.refreshIdentities(
       this.props.api,
       this.props.identityAddresses)
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     this.setState({
       localIdentities: nextProps.localIdentities
     })
@@ -93,7 +93,7 @@ class AllProfilesPage extends Component {
   }
 
   createNewProfile = (event) => {
-    logger.trace('createNewProfile')
+    logger.info('createNewProfile')
     event.preventDefault()
 
     if (!this.props.isProcessing) {

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -112,7 +112,7 @@ class DefaultProfilePage extends Component {
   }
 
   componentWillMount() {
-    logger.trace('componentWillMount')
+    logger.info('componentWillMount')
     this.props.refreshIdentities(this.props.api, this.props.identityAddresses)
   }
 
@@ -357,10 +357,10 @@ class DefaultProfilePage extends Component {
   }
 
   componentHasNewLocalIdentities(props) {
-    logger.trace('componentHasNewLocalIdentities')
+    logger.info('componentHasNewLocalIdentities')
     const identityIndex = this.props.defaultIdentity
     if (props.localIdentities[identityIndex]) {
-      logger.trace('componentHasNewLocalIdentities: identity found')
+      logger.info('componentHasNewLocalIdentities: identity found')
       const newProfile = props.localIdentities[identityIndex].profile
       const newUsername = props.localIdentities[identityIndex].username
 
@@ -369,7 +369,7 @@ class DefaultProfilePage extends Component {
         username: newUsername
       })
     } else {
-      logger.trace('componentHasNewLocalIdentities: no identity found')
+      logger.info('componentHasNewLocalIdentities: no identity found')
     }
   }
 
@@ -386,7 +386,7 @@ class DefaultProfilePage extends Component {
   }
 
   saveProfile(newProfile) {
-    logger.trace('saveProfile')
+    logger.info('saveProfile')
 
     const identityIndex = this.props.defaultIdentity
     const identity = this.props.localIdentities[identityIndex]
@@ -396,7 +396,7 @@ class DefaultProfilePage extends Component {
       newProfile,
       identity.zoneFile
     )
-    logger.trace('saveProfile: Preparing to upload profile')
+    logger.info('saveProfile: Preparing to upload profile')
     logger.debug(`saveProfile: signing with key index ${identityIndex}`)
 
     const identitySigner = this.props.identityKeypairs[identityIndex]
@@ -539,7 +539,7 @@ class DefaultProfilePage extends Component {
     const accounts = profile.account
 
     if (accounts) {
-      logger.trace('Removing account')
+      logger.info('Removing account')
       const newAccounts = accounts.filter(
         account => account.service !== service
       )

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -30,7 +30,7 @@ import { VERIFICATION_TWEET_LINK_URL_BASE } from './components/VerificationInfo'
 import log4js from 'log4js'
 import { defaultAvatartImage } from '@components/ui/common/constants'
 
-const logger = log4js.getLogger('profiles/DefaultProfilePage.js')
+const logger = log4js.getLogger(__filename)
 
 const accountTypes = [
   'twitter',

--- a/app/js/profiles/EditProfilePage.js
+++ b/app/js/profiles/EditProfilePage.js
@@ -228,10 +228,10 @@ class EditProfilePage extends Component {
   }
 
   componentHasNewLocalIdentities(props) {
-    logger.trace('componentHasNewLocalIdentities')
+    logger.info('componentHasNewLocalIdentities')
     const identityIndex = this.props.routeParams.index
     if (props.localIdentities[identityIndex]) {
-      logger.trace('componentHasNewLocalIdentities: identity found')
+      logger.info('componentHasNewLocalIdentities: identity found')
       const newIndex = identityIndex
       const newProfile = props.localIdentities[identityIndex].profile
       const newUsername = props.localIdentities[identityIndex].username
@@ -243,7 +243,7 @@ class EditProfilePage extends Component {
         username: newUsername
       })
     } else {
-      logger.trace('componentHasNewLocalIdentities: no identity found')
+      logger.info('componentHasNewLocalIdentities: no identity found')
     }
   }
 
@@ -264,7 +264,7 @@ class EditProfilePage extends Component {
   }
 
   saveProfile(newProfile) {
-    logger.trace('saveProfile')
+    logger.info('saveProfile')
 
     const identityIndex = this.props.routeParams.index
     const identity = this.props.localIdentities[identityIndex]
@@ -274,7 +274,7 @@ class EditProfilePage extends Component {
       newProfile,
       identity.zoneFile
     )
-    logger.trace('saveProfile: Preparing to upload profile')
+    logger.info('saveProfile: Preparing to upload profile')
     logger.debug(`saveProfile: signing with key index ${identityIndex}`)
 
     const identitySigner = this.props.identityKeypairs[identityIndex]

--- a/app/js/profiles/EditProfilePage.js
+++ b/app/js/profiles/EditProfilePage.js
@@ -16,7 +16,7 @@ import { Person } from 'blockstack'
 import log4js from 'log4js'
 import { defaultAvatartImage } from '@components/ui/common/constants'
 
-const logger = log4js.getLogger('profiles/EditProfilePage.js')
+const logger = log4js.getLogger(__filename)
 
 const accountTypes = [
   'twitter',

--- a/app/js/profiles/RegisterProfilePage.js
+++ b/app/js/profiles/RegisterProfilePage.js
@@ -15,7 +15,7 @@ import roundTo from 'round-to'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/RegisterProfilePage.js')
+const logger = log4js.getLogger(__filename)
 
 const WALLET_URL = '/wallet/receive'
 const STORAGE_URL = '/account/storage'

--- a/app/js/profiles/RegisterProfilePage.js
+++ b/app/js/profiles/RegisterProfilePage.js
@@ -105,7 +105,7 @@ class RegisterPage extends Component {
   }
 
   componentDidMount() {
-    logger.trace('componentDidMount')
+    logger.info('componentDidMount')
     this.props.refreshCoreWalletBalance(this.props.addressBalanceUrl,
       this.props.coreAPIPassword)
     logger.debug('getting core wallet address...')
@@ -117,7 +117,7 @@ class RegisterPage extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     // Clear alerts
     this.setState({
       alerts: []
@@ -241,7 +241,7 @@ class RegisterPage extends Component {
       const domainName = `${this.state.username}.${tld}`
       
       this.timer = setTimeout(() => {
-        logger.trace('Timer fired')
+        logger.info('Timer fired')
         if (!isABlockstackName(domainName)) {
           _this.updateAlert('danger', `${domainName} Not valid Blockstack name`)
           return
@@ -253,7 +253,7 @@ class RegisterPage extends Component {
   }
 
   updateAlert(alertStatus, alertMessage, url = null) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{
         status: alertStatus,
@@ -264,7 +264,7 @@ class RegisterPage extends Component {
   }
 
   registerIdentity(event) {
-    logger.trace('registerIdentity')
+    logger.info('registerIdentity')
     event.preventDefault()
 
     const ownerAddress = this.props.routeParams.index

--- a/app/js/profiles/SearchProfilesPage.js
+++ b/app/js/profiles/SearchProfilesPage.js
@@ -7,7 +7,7 @@ import SearchItem from './components/SearchItem'
 import { SearchActions } from './store/search/index'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/SearchProfilesPage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/profiles/SearchProfilesPage.js
+++ b/app/js/profiles/SearchProfilesPage.js
@@ -52,7 +52,7 @@ class SearchPage extends Component {
   }
 
   componentHasNewRouteParams(routeParams) {
-    logger.trace('componentHasNewRouteParams')
+    logger.info('componentHasNewRouteParams')
     logger.debug(`Searching for ${routeParams.query}...`)
     this.props.searchIdentities(routeParams.query,
       this.props.api.searchServiceUrl, this.props.api.nameLookupUrl)

--- a/app/js/profiles/TransferNamePage.js
+++ b/app/js/profiles/TransferNamePage.js
@@ -69,11 +69,11 @@ class TransferNamePage extends Component<Props, State> {
   }
 
   componentWillMount() {
-    logger.trace('componentWillMount')
+    logger.info('componentWillMount')
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     this.displayAlerts(nextProps)
   }
 
@@ -121,7 +121,7 @@ class TransferNamePage extends Component<Props, State> {
 
   updateAlert: Function
   updateAlert(alertStatus, alertMessage) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{ status: alertStatus, message: alertMessage }]
     })
@@ -129,7 +129,7 @@ class TransferNamePage extends Component<Props, State> {
 
   transferName: Function
   transferName(event) {
-    logger.trace('transferName')
+    logger.info('transferName')
     event.preventDefault()
     this.setState(() => ({
       clickedBroadcast: true,

--- a/app/js/profiles/TransferNamePage.js
+++ b/app/js/profiles/TransferNamePage.js
@@ -11,7 +11,7 @@ import AdvancedSidebar from './components/AdvancedSidebar'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/TransferNamePage.js')
+const logger = log4js.getLogger(__filename)
 
 type Props = {
   coreAPIPassword: string,

--- a/app/js/profiles/ZoneFilePage.js
+++ b/app/js/profiles/ZoneFilePage.js
@@ -68,7 +68,7 @@ class ZoneFilePage extends Component {
   }
 
   componentWillMount() {
-    logger.trace('componentWillMount')
+    logger.info('componentWillMount')
     const name = this.props.routeParams.index
     this.props.fetchCurrentIdentity(
       this.props.nameLookupUrl,
@@ -78,7 +78,7 @@ class ZoneFilePage extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     const currentIdentity = nextProps.currentIdentity
     const zoneFile = currentIdentity.zoneFile
     if (zoneFile && !nextProps.edited) {
@@ -129,7 +129,7 @@ class ZoneFilePage extends Component {
   }
 
   reset(event) {
-    logger.trace('reset')
+    logger.info('reset')
     event.preventDefault()
     this.setState({
       clickedBroadcast: false,
@@ -140,14 +140,14 @@ class ZoneFilePage extends Component {
   }
 
   updateAlert(alertStatus, alertMessage) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{ status: alertStatus, message: alertMessage }]
     })
   }
 
   updateZoneFile(event) {
-    logger.trace('updateZoneFile')
+    logger.info('updateZoneFile')
     event.preventDefault()
     this.setState({
       clickedBroadcast: true,

--- a/app/js/profiles/ZoneFilePage.js
+++ b/app/js/profiles/ZoneFilePage.js
@@ -12,7 +12,7 @@ import AdvancedSidebar from './components/AdvancedSidebar'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/ZoneFilePage.js')
+const logger = log4js.getLogger(__filename)
 
 function mapStateToProps(state) {
   return {

--- a/app/js/profiles/components/IdentityItem.js
+++ b/app/js/profiles/components/IdentityItem.js
@@ -30,7 +30,7 @@ class IdentityItem extends Component {
   transferFromOnenameClick = event => {
     event.preventDefault()
     event.stopPropagation()
-    logger.trace('transferFromOnenameClick')
+    logger.info('transferFromOnenameClick')
     const identityAddress = this.props.ownerAddress
     const profileUrl = this.props.profileUrl
     const url = `https://onename.com/settings?action=export&address=${identityAddress}&url=${profileUrl}`

--- a/app/js/profiles/components/IdentityItem.js
+++ b/app/js/profiles/components/IdentityItem.js
@@ -6,7 +6,7 @@ import { UserAvatar } from '@blockstack/ui'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/components/IdentityItem.js')
+const logger = log4js.getLogger(__filename)
 
 class IdentityItem extends Component {
   static propTypes = {

--- a/app/js/profiles/components/registration/RegistrationSearchView.js
+++ b/app/js/profiles/components/registration/RegistrationSearchView.js
@@ -78,14 +78,14 @@ class RegistrationSearchView extends Component {
   }
 
   componentDidMount() {
-    logger.trace('componentDidMount')
+    logger.info('componentDidMount')
     const { refreshCoreWalletBalance, balanceUrl, api } = this.props
     refreshCoreWalletBalance(balanceUrl, api.coreAPIPassword)
   }
 
 
   componentWillReceiveProps() {
-    logger.trace('componentWillReceiveProps')
+    logger.info('componentWillReceiveProps')
     // Clear alerts
     this.setState({
       alerts: []
@@ -108,7 +108,7 @@ class RegistrationSearchView extends Component {
   onOnenameTransferClick = (event) => {
     event.preventDefault()
     event.stopPropagation()
-    logger.trace('transferFromOnenameClick')
+    logger.info('transferFromOnenameClick')
     const identityIndex = this.props.defaultIdentity
     const identity = this.props.localIdentities[identityIndex]
     const identityAddress = identity.ownerAddress
@@ -123,7 +123,7 @@ class RegistrationSearchView extends Component {
   }
 
   search(event) {
-    logger.trace('search')
+    logger.info('search')
     const username = this.state.username
     logger.debug(`search: user is searching for ${username}`)
     event.preventDefault()
@@ -144,7 +144,7 @@ class RegistrationSearchView extends Component {
   }
 
   showSearchBox(event) {
-    logger.trace('showSearchBox')
+    logger.info('showSearchBox')
     event.preventDefault()
     this.setState({
       username: '',
@@ -154,7 +154,7 @@ class RegistrationSearchView extends Component {
   }
 
   updateAlert(alertStatus, alertMessage, url = null) {
-    logger.trace(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
+    logger.info(`updateAlert: alertStatus: ${alertStatus}, alertMessage ${alertMessage}`)
     this.setState({
       alerts: [{
         status: alertStatus,

--- a/app/js/profiles/components/registration/RegistrationSearchView.js
+++ b/app/js/profiles/components/registration/RegistrationSearchView.js
@@ -14,7 +14,7 @@ import { isABlockstackName } from '@utils/name-utils'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/components/registration/RegistrationSearchView.js')
+const logger = log4js.getLogger(__filename)
 
 const STORAGE_URL = '/account/storage'
 

--- a/app/js/profiles/components/registration/RegistrationSelectView.js
+++ b/app/js/profiles/components/registration/RegistrationSelectView.js
@@ -15,7 +15,7 @@ import Alert from '@components/Alert'
 import InputGroup from '@components/InputGroup'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/components/registration/RegistrationSelectView.js')
+const logger = log4js.getLogger(__filename)
 const CHECK_FOR_PAYMENT_INTERVAL = 10000
 export const PRICE_BUFFER = 0.0005 // btc
 function mapStateToProps(state) {

--- a/app/js/profiles/components/registration/RegistrationSelectView.js
+++ b/app/js/profiles/components/registration/RegistrationSelectView.js
@@ -113,7 +113,7 @@ class AddUsernameSelectPage extends Component {
   }
 
   componentDidMount() {
-    logger.trace('componentDidMount')
+    logger.info('componentDidMount')
     this.props.refreshBalances(this.props.insightUrl, this.props.addresses,
           this.props.api.coreAPIPassword)
 
@@ -178,7 +178,7 @@ class AddUsernameSelectPage extends Component {
   }
 
   register(event) {
-    logger.trace('register')
+    logger.info('register')
 
     if (event) {
       event.preventDefault()

--- a/app/js/profiles/store/availability/actions.js
+++ b/app/js/profiles/store/availability/actions.js
@@ -6,7 +6,7 @@ import {
   isNameAvailable, getNamePrices
 } from '@utils/index'
 
-const logger = log4js.getLogger('profiles/store/availability/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function checkingNameAvailability(domainName) {
   return {

--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -20,7 +20,7 @@ import type { Dispatch } from 'redux'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/store/identity/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function validateProofsService(
   profile: Object,

--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -209,15 +209,15 @@ function createNewProfile(
   nextUnusedAddressIndex: number
 ) {
   return (dispatch: Dispatch<*>, getState: () => any): Promise<*> => {
-    logger.trace('createNewProfile')
+    logger.info('createNewProfile')
 
     const state = getState()
     if (state.profiles && state.profiles.identity && state.profiles.identity.isProcessing) {
-      logger.trace('createNewProfile: Early exit because isProcessing')
+      logger.info('createNewProfile: Early exit because isProcessing')
       return Promise.resolve()
     }
 
-    logger.trace('createNewProfile: Dispatch CREATE_NEW_REQUEST')
+    logger.info('createNewProfile: Dispatch CREATE_NEW_REQUEST')
     dispatch({ type: types.CREATE_NEW_REQUEST })
 
     // Decrypt master keychain
@@ -272,7 +272,7 @@ function refreshIdentities(
   ownerAddresses: Array<string>
 ) {
   return (dispatch: Dispatch<*>): Promise<*> => {
-    logger.trace('refreshIdentities')
+    logger.info('refreshIdentities')
 
     const promises: Array<Promise<*>> = ownerAddresses.map((address, index) => {
       const promise: Promise<*> = new Promise(resolve => {
@@ -532,7 +532,7 @@ function broadcastZoneFileUpdate(
   keypair: { key: string },
   zoneFile: string
 ) {
-  logger.trace('broadcastZoneFileUpdate: entering')
+  logger.info('broadcastZoneFileUpdate: entering')
   return (dispatch: Dispatch<*>): Promise<*> => {
     dispatch(broadcastingZoneFileUpdate(name))
     // Core registers with an uncompressed address,
@@ -588,7 +588,7 @@ function broadcastNameTransfer(
   keypair: { key: string },
   newOwnerAddress: string
 ) {
-  logger.trace('broadcastNameTransfer: entering')
+  logger.info('broadcastNameTransfer: entering')
   return (dispatch: Dispatch<*>): Promise<*> => {
     dispatch(broadcastingNameTransfer(name))
     // Core registers with an uncompressed address,

--- a/app/js/profiles/store/pgp/actions.js
+++ b/app/js/profiles/store/pgp/actions.js
@@ -1,7 +1,7 @@
 import * as types from './types'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/store/pgp/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function loadingPGPKey(identifier) {
   return {

--- a/app/js/profiles/store/pgp/actions.js
+++ b/app/js/profiles/store/pgp/actions.js
@@ -27,7 +27,7 @@ function loadedPGPKey(identifier, key) {
 }
 
 function loadPGPPublicKey(contentUrl, identifier) {
-  logger.trace('loadPGPPublicKey')
+  logger.info('loadPGPPublicKey')
   return dispatch => {
     dispatch(loadingPGPKey(identifier))
     return proxyFetch(contentUrl)

--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -7,7 +7,7 @@ import { DEFAULT_PROFILE } from '@utils/profile-utils'
 import { isSubdomain, getNameSuffix } from '@utils/name-utils'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/store/registration/actions.js')
+const logger = log4js.getLogger(__filename)
 
 
 function profileUploading() {

--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -49,7 +49,7 @@ function registrationError(error) {
 }
 
 function beforeRegister() {
-  logger.trace('beforeRegister')
+  logger.info('beforeRegister')
   return dispatch => {
     dispatch(registrationBeforeSubmit())
   }
@@ -73,7 +73,7 @@ function registerSubdomain(api, domainName, identityIndex, ownerAddress, zoneFil
     Authorization: authorizationHeaderValue(api.coreAPIPassword)
   }
 
-  logger.trace(`Submitting registration for ${domainName} to ${registerUrl}`)
+  logger.info(`Submitting registration for ${domainName} to ${registerUrl}`)
 
   return fetch(registerUrl, {
     method: 'POST',
@@ -137,21 +137,21 @@ function registerDomain(myNet, tx, domainName, identityIndex, ownerAddress, paym
 
 function registerName(api, domainName, identity, identityIndex,
                       ownerAddress, keypair, paymentKey = null) {
-  logger.trace(`registerName: domainName: ${domainName}`)
+  logger.info(`registerName: domainName: ${domainName}`)
   return dispatch => {
     logger.debug(`Signing a new profile for ${domainName}`)
     const profile = identity.profile || DEFAULT_PROFILE
     const signedProfileTokenData = signProfileForUpload(profile, keypair)
 
     dispatch(profileUploading())
-    logger.trace(`Uploading ${domainName} profile...`)
+    logger.info(`Uploading ${domainName} profile...`)
     return uploadProfile(api, identity, keypair, signedProfileTokenData)
     .then((profileUrl) => {
-      logger.trace(`Uploading ${domainName} profiled succeeded.`)
+      logger.info(`Uploading ${domainName} profiled succeeded.`)
       const tokenFileUrl = profileUrl
       logger.debug(`tokenFileUrl: ${tokenFileUrl}`)
 
-      logger.trace('Making profile zonefile...')
+      logger.info('Making profile zonefile...')
       const zoneFile = makeProfileZoneFile(domainName, tokenFileUrl)
 
       const nameIsSubdomain = isSubdomain(domainName)
@@ -177,7 +177,7 @@ function registerName(api, domainName, identity, identityIndex,
           })
       } else {
         if (api.regTestMode) {
-          logger.trace('Using regtest network')
+          logger.info('Using regtest network')
           config.network = network.defaults.LOCAL_REGTEST
           // browser regtest environment uses 6270
           config.network.blockstackAPIUrl = 'http://localhost:6270'

--- a/app/js/profiles/store/search/actions.js
+++ b/app/js/profiles/store/search/actions.js
@@ -2,7 +2,7 @@ import * as types from './types'
 import { compareProfilesByVerifications } from '@utils/index'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/store/search/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function updateQuery(query) {
   return {

--- a/app/js/profiles/store/search/actions.js
+++ b/app/js/profiles/store/search/actions.js
@@ -20,7 +20,7 @@ function updateResults(query, results) {
 }
 
 function searchIdentities(query, searchUrl, lookupUrl) {
-  logger.trace(`searchIdentities: query: "${query}" searchUrl: ${searchUrl} ${lookupUrl}`)
+  logger.info(`searchIdentities: query: "${query}" searchUrl: ${searchUrl} ${lookupUrl}`)
   return dispatch => {
     let url
     let username

--- a/app/js/sign-in/index.js
+++ b/app/js/sign-in/index.js
@@ -38,7 +38,7 @@ import App from '../App'
 
 const CREATE_ACCOUNT_IN_PROCESS = 'createAccount/in_process'
 
-const logger = log4js.getLogger('sign-in/index.js')
+const logger = log4js.getLogger(__filename)
 
 const VIEWS = {
   INITIAL: 0,

--- a/app/js/sign-up/index.js
+++ b/app/js/sign-up/index.js
@@ -218,7 +218,7 @@ class Onboarding extends React.Component {
     const suffix = `.${SUBDOMAIN_SUFFIX}`
     username += suffix
     console.log('about to submit username', username)
-    logger.trace('registerUsername')
+    logger.info('registerUsername')
     const nameHasBeenPreordered = hasNameBeenPreordered(
       username,
       this.props.localIdentities

--- a/app/js/sign-up/index.js
+++ b/app/js/sign-up/index.js
@@ -49,7 +49,7 @@ import {
   RecoveryInformationScreen
 } from './views'
 
-const logger = log4js.getLogger('onboarding/index.js')
+const logger = log4js.getLogger(__filename)
 
 const views = [
   Initial,

--- a/app/js/sign-up/views/_username.js
+++ b/app/js/sign-up/views/_username.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { ShellScreen } from '@blockstack/ui'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('onboarding/Username.js')
+const logger = log4js.getLogger(__filename)
 const defaultSponsoredName = '.id.blockstack'
 
 /**

--- a/app/js/store/apps/actions.js
+++ b/app/js/store/apps/actions.js
@@ -2,7 +2,7 @@ import * as types from './types'
 import log4js from 'log4js'
 import { randomBytes, createHash } from 'crypto'
 
-const logger = log4js.getLogger('store/apps/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function updateAppList(apps, version) {
   const lastUpdated = Date.now()

--- a/app/js/store/apps/actions.js
+++ b/app/js/store/apps/actions.js
@@ -25,7 +25,7 @@ function updateInstanceIdentifier(instanceIdentifier) {
 
 function refreshAppList(browserApiUrl, instanceIdentifier, instanceCreationDate) {
   return dispatch => {
-    logger.trace('refreshAppList')
+    logger.info('refreshAppList')
     if (instanceIdentifier) {
       return fetch(`${browserApiUrl}/data?id=${instanceIdentifier}&created=${instanceCreationDate}`)
         .then(response => response.text())
@@ -43,7 +43,7 @@ function refreshAppList(browserApiUrl, instanceIdentifier, instanceCreationDate)
 }
 
 function generateInstanceIdentifier() {
-  logger.trace('Generating new instance identifier')
+  logger.info('Generating new instance identifier')
   return dispatch => {
     const instanceIdentifier = createHash('sha256')
       .update(randomBytes(256))

--- a/app/js/store/sanity/actions.js
+++ b/app/js/store/sanity/actions.js
@@ -4,7 +4,7 @@ import log4js from 'log4js'
 import { isApiPasswordValid, isCoreApiRunning } from '../../utils/api-utils'
 import { isCoreEndpointDisabled } from '../../utils/window-utils'
 
-const logger = log4js.getLogger('store/sanity/actions.js')
+const logger = log4js.getLogger(__filename)
 
 function coreApiPasswordIsNotValid() {
   return {

--- a/app/js/utils/account-utils.js
+++ b/app/js/utils/account-utils.js
@@ -4,7 +4,7 @@ import { HDNode } from 'bitcoinjs-lib'
 import crypto from 'crypto'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('utils/account-utils.js')
+const logger = log4js.getLogger(__filename)
 
 function hashCode(string) {
   let hash = 0

--- a/app/js/utils/account-utils.js
+++ b/app/js/utils/account-utils.js
@@ -137,7 +137,7 @@ export function decryptMasterKeychain(password, encryptedBackupPhrase) {
         const backupPhrase = plaintextBuffer.toString()
         const seed = bip39.mnemonicToSeed(backupPhrase)
         const masterKeychain = HDNode.fromSeedBuffer(seed)
-        logger.trace('decryptMasterKeychain: decrypted!')
+        logger.info('decryptMasterKeychain: decrypted!')
         resolve(masterKeychain)
       },
       error => {

--- a/app/js/utils/api-utils.js
+++ b/app/js/utils/api-utils.js
@@ -137,7 +137,7 @@ export function isCoreApiRunning(corePingUrl) {
       .then(responseText => JSON.parse(responseText))
       .then(responseJson => {
         if (responseJson.status === 'alive') {
-          logger.trace('isCoreApiRunning? Yes!')
+          logger.info('isCoreApiRunning? Yes!')
           resolve(true)
         } else {
           logger.error('isCoreApiRunning? No!')
@@ -178,7 +178,7 @@ export function isApiPasswordValid(corePasswordProtectedReadUrl, coreApiPassword
     })
       .then(response => {
         if (response.ok) {
-          logger.trace('isCoreApiPasswordValid? Yes!')
+          logger.info('isCoreApiPasswordValid? Yes!')
           resolve(true)
         } else {
           logger.error('isCoreApiPasswordValid? No!')

--- a/app/js/utils/api-utils.js
+++ b/app/js/utils/api-utils.js
@@ -1,7 +1,7 @@
 import hash from 'hash-handler'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('utils/api-utils.js')
+const logger = log4js.getLogger(__filename)
 
 import {
   DEFAULT_CORE_API_ENDPOINT, REGTEST_CORE_API_ENDPOINT, REGTEST_CORE_API_PASSWORD,

--- a/app/js/utils/bitcoin-utils.js
+++ b/app/js/utils/bitcoin-utils.js
@@ -3,7 +3,7 @@ import {
   REGTEST_CORE_API_PASSWORD,
   REGTEST_CORE_INSIGHT_API_URL
 } from '../account/store/settings/default'
-const logger = log4js.getLogger('utils/bitcoin-utils.js')
+const logger = log4js.getLogger(__filename)
 
 const SATOSHIS_IN_BTC = 100000000
 

--- a/app/js/utils/logging-utils.js
+++ b/app/js/utils/logging-utils.js
@@ -46,7 +46,7 @@ export function configureLogging(log4js, logServerPort, authorizationHeaderValue
     replaceConsole: false
   })
 
-  const logger = log4js.getLogger('utils/logging-utils.js')
+  const logger = log4js.getLogger(__filename)
   logger.info('Logging system enabled')
 
   if (remoteLoggingEnabled) {

--- a/app/js/utils/name-utils.js
+++ b/app/js/utils/name-utils.js
@@ -1,6 +1,6 @@
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('utils/name-utils.js')
+const logger = log4js.getLogger(__filename)
 
 export function isABlockstackName(s) {
   return /^[a-z0-9_-]+\.[a-z0-9_-]+$/.test(s)

--- a/app/js/utils/profile-utils.js
+++ b/app/js/utils/profile-utils.js
@@ -5,7 +5,7 @@ import ecurve from 'ecurve'
 import { ECPair as ECKeyPair } from 'bitcoinjs-lib'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('utils/profile-utils.js')
+const logger = log4js.getLogger(__filename)
 
 const secp256k1 = ecurve.getCurveByName('secp256k1')
 

--- a/app/js/utils/zone-utils.js
+++ b/app/js/utils/zone-utils.js
@@ -3,7 +3,7 @@ import { getProfileFromTokens } from './profile-utils'
 import { parseZoneFile } from 'zone-file'
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('utils/zone-utils.js')
+const logger = log4js.getLogger(__filename)
 
 export function getTokenFileUrlFromZoneFile(zoneFileJson) {
   if (!zoneFileJson.hasOwnProperty('uri')) {

--- a/app/js/wallet/components/Balance.js
+++ b/app/js/wallet/components/Balance.js
@@ -10,7 +10,7 @@ import roundTo from 'round-to'
 
 import log4js from 'log4js'
 
-const logger = log4js.getLogger('profiles/wallet/components/Balance.js')
+const logger = log4js.getLogger(__filename)
 
 const UPDATE_BALANCE_INTERVAL = 10000
 

--- a/test/account/store/account/actions.test.js
+++ b/test/account/store/account/actions.test.js
@@ -276,32 +276,22 @@ describe('AccountActions', () => {
       describe('fetches confirmedBalanceUrl', () => {
         describe('and when failing', () => {
           const error = new Error()
-          const loggerMock = {
-            debug: sinon.spy(),
-            error: sinon.spy()
-          }
 
           beforeEach(() => {
             sinon.stub(global, 'fetch').rejects(error)
-
-            AccountActions.__Rewire__('logger', loggerMock)
             callAction()
           })
 
           afterEach(() => {
             sinon.restore(global, 'fetch')
-            AccountActions.__ResetDependency__('logger')
           })
 
-          it('logs an expressive error', () => {
+          it('it does nothing', () => {
             const store = mockStore({})
 
             return store.dispatch(action)
-              .then(() => {
-                assert.deepEqual(loggerMock.error.firstCall.args, [
-                  `refreshBalances: error fetching ${address} confirmed balance`,
-                  error
-                ])
+              .catch(() => {
+                assert.equal(store.getActions().length, 0)
               })
           })
         })
@@ -329,33 +319,24 @@ describe('AccountActions', () => {
             describe(', then fetches unconfirmedBalanceUrl', () => {
               describe('and when failing', () => {
                 const error = new Error()
-                const loggerMock = {
-                  debug: sinon.spy(),
-                  error: sinon.spy()
-                }
 
                 beforeEach(() => {
                   fetchStub
                     .withArgs(getInsightUrlsResult.unconfirmedBalanceUrl)
                     .rejects(error)
-                  AccountActions.__Rewire__('logger', loggerMock)
                   callAction()
                 })
 
                 afterEach(() => {
                   sinon.restore(global, 'fetch')
-                  AccountActions.__ResetDependency__('logger')
                 })
 
-                it('logs an expressive error', () => {
+                it('it does nothing', () => {
                   const store = mockStore({})
 
                   return store.dispatch(action)
-                    .then(() => {
-                      assert.deepEqual(loggerMock.error.firstCall.args, [
-                        `refreshBalances: error fetching ${address} unconfirmed balance`,
-                        error
-                      ])
+                    .catch(() => {
+                      assert.equal(store.getActions().length, 0)
                     })
                 })
               })
@@ -443,33 +424,13 @@ describe('AccountActions', () => {
 
                       describe('if has duplicate addresses', () => {
                         const duplicateAddresses = ['address1', 'address1', 'address2']
-                        const loggerMock = {
-                          debug: sinon.spy(),
-                          error: sinon.spy()
-                        }
 
                         beforeEach(() => {
-                          AccountActions.__Rewire__('logger', loggerMock)
                           action = AccountActions.refreshBalances(
                             insightUrl,
                             duplicateAddresses,
                             coreAPIPassword
                           )
-                        })
-
-                        afterEach(() => {
-                          AccountActions.__ResetDependency__('logger')
-                        })
-
-                        it('logs an expressive error', () => {
-                          const store = mockStore({})
-
-                          return store.dispatch(action)
-                            .then(() => {
-                              assert.deepEqual(loggerMock.error.firstCall.args, [
-                                `refreshBalances: Duplicate address ${duplicateAddresses[0]} in addresses array`
-                              ])
-                            })
                         })
 
                         it('only takes first occurrence of address into account', () => {
@@ -509,24 +470,16 @@ describe('AccountActions', () => {
   })
 
   describe('getCoreWalletAddress', () => {
-    const loggerMock = {
-      error: sinon.spy()
-    }
     const walletPaymentAddressUrl = 'fakeWalletPaymentAddressUrl'
     const coreAPIPassword = 'fakeCoreAPIPassword'
 
     let action
 
     beforeEach(() => {
-      AccountActions.__Rewire__('logger', loggerMock)
       action = AccountActions.getCoreWalletAddress(
         walletPaymentAddressUrl,
         coreAPIPassword
       )
-    })
-
-    afterEach(() => {
-      AccountActions.__ResetDependency__('logger')
     })
 
     describe('when isCoreEndpointDisabled', () => {
@@ -540,14 +493,11 @@ describe('AccountActions', () => {
         AccountActions.__ResetDependency__('isCoreEndpointDisabled')
       })
 
-      it('logs an expressive error and does nothing', () => {
+      it('it does nothing', () => {
         const store = mockStore({})
 
         return store.dispatch(action)
           .then(() => {
-            assert.deepEqual(loggerMock.error.firstCall.args, [
-              'Cannot use core wallet if core is disable'
-            ])
             assert.equal(store.getActions().length, 0)
           })
       })
@@ -591,15 +541,11 @@ describe('AccountActions', () => {
             fetchStub.rejects(error)
           })
 
-          it('logs an expressive error and does nothing', () => {
+          it('it does nothing', () => {
             const store = mockStore({})
 
             return store.dispatch(action)
               .catch(() => {
-                assert.deepEqual(loggerMock.error.firstCall.args, [
-                  'getCoreWalletAddress: error fetching address',
-                  error
-                ])
                 assert.equal(store.getActions().length, 0)
               })
           })
@@ -632,27 +578,16 @@ describe('AccountActions', () => {
   })
 
   describe('refreshCoreWalletBalance', () => {
-    let loggerMock
     const addressBalanceUrl = 'fakeAddressBalanceUrl'
     const coreAPIPassword = 'fakeCoreAPIPassword'
 
     let action
 
     beforeEach(() => {
-      loggerMock = {
-        debug: sinon.spy(),
-        error: sinon.spy(),
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       action = AccountActions.refreshCoreWalletBalance(
         addressBalanceUrl,
         coreAPIPassword
       )
-    })
-
-    afterEach(() => {
-      AccountActions.__ResetDependency__('logger')
     })
 
     describe('when isCoreEndpointDisabled', () => {
@@ -664,17 +599,6 @@ describe('AccountActions', () => {
 
       afterEach(() => {
         AccountActions.__ResetDependency__('isCoreEndpointDisabled')
-      })
-
-      it('logs an expressive debug message', () => {
-        const store = mockStore({})
-
-        return store.dispatch(action)
-          .then(() => {
-            assert.deepEqual(loggerMock.debug.firstCall.args, [
-              'Mocking core wallet balance in webapp build'
-            ])
-          })
       })
 
       it('dispatches updateCoreWalletBalance(0)', () => {
@@ -718,35 +642,6 @@ describe('AccountActions', () => {
         afterEach(() => {
           AccountActions.__ResetDependency__('authorizationHeaderValue')
           sinon.restore(global, 'fetch')
-
-        })
-
-        describe('and even before failing', () => {
-          beforeEach(() => {
-            fetchStub.rejects()
-          })
-
-          it('logs a trace message', () => {
-            const store = mockStore({})
-
-            return store.dispatch(action)
-              .catch(() => {
-                assert.deepEqual(loggerMock.trace.firstCall.args, [
-                  'refreshCoreWalletBalance: Beginning refresh...'
-                ])
-              })
-          })
-
-          it('logs a debug message', () => {
-            const store = mockStore({})
-
-            return store.dispatch(action)
-              .catch(() => {
-                assert.deepEqual(loggerMock.debug.firstCall.args, [
-                  `refreshCoreWalletBalance: addressBalanceUrl: ${addressBalanceUrl}`
-                ])
-              })
-          })
         })
 
         describe('and when failing', () => {
@@ -756,15 +651,11 @@ describe('AccountActions', () => {
             fetchStub.rejects(error)
           })
 
-          it('logs an expressive error and does nothing', () => {
+          it('it does nothing', () => {
             const store = mockStore({})
 
             return store.dispatch(action)
               .catch(() => {
-                assert.deepEqual(loggerMock.error.firstCall.args, [
-                  'refreshCoreWalletBalance: error refreshing balance',
-                  error
-                ])
                 assert.equal(store.getActions().length, 0)
               })
           })
@@ -779,18 +670,7 @@ describe('AccountActions', () => {
           })
 
           describe('parses bitcoin balance from response', () => {
-            it('logs a debug message with bitcoin balance', () => {
-              const store = mockStore({})
-
-              return store.dispatch(action)
-                .catch(() => {
-                  assert.deepEqual(loggerMock.debug.lastCall.args, [
-                    `refreshCoreWalletBalance: balance is ${bitcoin}.`
-                  ])
-                })
-            })
-
-            it('and dispatches updateCoreWalletBalance with address', () => {
+            it('dispatches updateCoreWalletBalance with address', () => {
               const store = mockStore({})
 
               return store.dispatch(action)
@@ -848,23 +728,16 @@ describe('AccountActions', () => {
         recipientAddress,
         amountBTC
       )
-    let loggerMock
     let store
     let action
 
     beforeEach(() => {
-      loggerMock = {
-        trace: sinon.spy(),
-        error: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       store = mockStore({})
       AccountActions.__Rewire__('config', configMock)
       AccountActions.__Rewire__('network', networkMock)
     })
 
     afterEach(() => {
-      AccountActions.__ResetDependency__('logger')
       AccountActions.__ResetDependency__('config')
       AccountActions.__ResetDependency__('network')
     })
@@ -880,15 +753,6 @@ describe('AccountActions', () => {
       afterEach(() => {
         AccountActions.__ResetDependency__('transactions')
       })
-
-      it('logs a trace message', () =>
-        store.dispatch(action)
-          .then(() => {
-            assert.deepEqual(loggerMock.trace.firstCall.args, [
-              'Using regtest network'
-            ])
-          })
-      )
 
       it('sets config.network to LOCAL_REGTEST', () =>
         store.dispatch(action)
@@ -1023,16 +887,6 @@ describe('AccountActions', () => {
           AccountActions.__ResetDependency__('transactions')
         })
 
-        it('logs an expressive error', () =>
-          store.dispatch(action)
-            .then(() => {
-              assert.deepEqual(loggerMock.error.firstCall.args, [
-                'withdrawBitcoinClientSide: error generating and broadcasting',
-                error
-              ])
-            })
-        )
-
         it('dispatches withdrawCoreBalanceError with error', () =>
           store.dispatch(action)
             .then(() => {
@@ -1064,15 +918,6 @@ describe('AccountActions', () => {
           beforeEach(() => {
             action = callAction(false)
           })
-
-          it('after logging a trace message with the transactionHex', () =>
-            store.dispatch(action)
-              .then(() => {
-                assert.deepEqual(loggerMock.trace.lastCall.args, [
-                  `Broadcast btc spend with tx hex: ${transactionHex}`
-                ])
-              })
-          )
 
           it('to the config.network via .broadcastTransaction', () =>
             store.dispatch(action)
@@ -1109,25 +954,14 @@ describe('AccountActions', () => {
     const coreAPIPassword = 'fakeCoreAPIPassword'
     let store
     let action
-    let loggerMock
 
     beforeEach(() => {
       store = mockStore({})
-      loggerMock = {
-        debug: sinon.spy(),
-        error: sinon.spy(),
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       action = AccountActions.withdrawBitcoinFromCoreWallet(
         coreWalletWithdrawUrl,
         recipientAddress,
         coreAPIPassword
       )
-    })
-
-    afterEach(() => {
-      AccountActions.__ResetDependency__('logger')
     })
 
     describe('when isCoreEndpointDisabled', () => {
@@ -1216,22 +1050,10 @@ describe('AccountActions', () => {
             )
           })
         })
-
-        it('logs a debug message with recipientAddress', () =>
-          store.dispatch(action)
-            .catch(() => {
-              assert.deepEqual(loggerMock.debug.firstCall.args, [
-                `withdrawBitcoinFromCoreWallet: send all money to ${recipientAddress}`
-              ])
-            })
-        )
       })
 
       describe('when amount is defined', () => {
         const amountBTC = 1
-        const btcToSatoshis = btc => btc * 1e8
-        const roundTo = x => Math.round(x)
-        const roundedSatoshiAmount = roundTo(btcToSatoshis(amountBTC))
 
         beforeEach(() => {
           action = AccountActions.withdrawBitcoinFromCoreWallet(
@@ -1241,15 +1063,6 @@ describe('AccountActions', () => {
             amountBTC
           )
         })
-
-        it('logs a debug message with roundedSatoshiAmount and recipientAddress', () =>
-          store.dispatch(action)
-            .catch(() => {
-              assert.deepEqual(loggerMock.debug.firstCall.args, [
-                `withdrawBitcoinFromCoreWallet: ${roundedSatoshiAmount} to ${recipientAddress}`
-              ])
-            })
-        )
 
         describe('dispatches a withdrawingCoreBalance action', () => {
           it('with type WITHDRAWING_CORE_BALANCE', () =>
@@ -1286,40 +1099,6 @@ describe('AccountActions', () => {
             )
           })
         })
-      })
-
-      describe('when paymentKey is not defined', () => {
-        it('logs a debug message stating No payment key', () =>
-          store.dispatch(action)
-            .catch(() => {
-              assert.deepEqual(loggerMock.debug.secondCall.args, [
-                'withdrawBitcoinFromCoreWallet: No payment key, using core wallet'
-              ])
-            })
-        )
-      })
-
-      describe('when paymentKey is defined', () => {
-        const paymentKey = 'fakePaymentKey'
-
-        beforeEach(() => {
-          action = AccountActions.withdrawBitcoinFromCoreWallet(
-            coreWalletWithdrawUrl,
-            recipientAddress,
-            coreAPIPassword,
-            null,
-            paymentKey
-          )
-        })
-
-        it('logs a debug message stating Using provided payment key', () =>
-          store.dispatch(action)
-            .catch(() => {
-              assert.deepEqual(loggerMock.debug.secondCall.args, [
-                'withdrawBitcoinFromCoreWallet: Using provided payment key'
-              ])
-            })
-        )
       })
 
       describe('fetches coreWalletWithdrawUrl', () => {
@@ -1450,24 +1229,6 @@ describe('AccountActions', () => {
           })
         })
 
-        describe('and when failing', () => {
-          const error = new Error()
-
-          beforeEach(() => {
-            sinon.restore(global, 'fetch')
-            sinon.stub(global, 'fetch').rejects(error)
-          })
-
-          it('logs an expressive error message', () =>
-            store.dispatch(action)
-              .catch(() => assert.deepEqual(loggerMock.error.firstCall.args, [
-                'withdrawBitcoinFromCoreWallet:',
-                error
-              ])
-            )
-          )
-        })
-
         describe('and when working', () => {
           describe('when provided with an erroneous response', () => {
             const errorFromResponse = 'an error'
@@ -1514,12 +1275,8 @@ describe('AccountActions', () => {
     let optIn
     let action
     let store
-    let loggerMock
 
     beforeEach(() => {
-      loggerMock = {
-        debug: sinon.spy()
-      }
       sinon.stub(global, 'fetch').rejects(new Error())
       store = mockStore({})
       action = AccountActions.emailNotifications(
@@ -1531,13 +1288,6 @@ describe('AccountActions', () => {
     afterEach(() => {
       sinon.restore(global, 'fetch')
     })
-
-    it('logs a debug message with email', () =>
-      store.dispatch(action)
-        .catch(() => assert.deepEqual(loggerMock.debug.firstCall.args, [
-          `emailNotifications: ${email}`
-        ]))
-    )
 
     describe('dispatches promptedForEmail action', () => {
       it('with type PROMPTED_FOR_EMAIL', () =>
@@ -1621,14 +1371,6 @@ describe('AccountActions', () => {
           sinon.restore(global, 'fetch')
           sinon.stub(global, 'fetch').rejects(error)
         })
-
-        it('logs an expressive error', () =>
-          store.dispatch(action)
-            .catch(() => assert.deepEqual(loggerMock.error.firstCall.args, [
-              'emailNotifications: error',
-              error
-            ]))
-        )
       })
 
       describe('and when working', () => {
@@ -1636,39 +1378,17 @@ describe('AccountActions', () => {
           sinon.restore(global, 'fetch')
           sinon.stub(global, 'fetch').resolves()
         })
-
-        it('logs a debug message with email', () =>
-          store.dispatch(action)
-            .catch(() => assert.deepEqual(loggerMock.debug.secondCall.args, [
-              `emailNotifications: registered ${email} for notifications`
-            ]))
-        )
       })
     })
   })
 
   describe('skipEmailBackup', () => {
-    let loggerMock
     let store
 
     beforeEach(() => {
-      loggerMock = {
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       store = mockStore({})
       store.dispatch(AccountActions.skipEmailBackup())
     })
-
-    afterEach(() =>
-      AccountActions.__ResetDependency__('logger')
-    )
-
-    it('logs a trace message', () =>
-      assert.deepEqual(loggerMock.trace.firstCall.args, [
-        'skipEmailBackup'
-      ])
-    )
 
     it('dispatches action {type: PROMPTED_FOR_EMAIL, email: null}', () =>
       assert.deepEqual(store.getActions()[0], {
@@ -1679,27 +1399,12 @@ describe('AccountActions', () => {
   })
 
   describe('storageIsConnected', () => {
-    let loggerMock
     let store
 
     beforeEach(() => {
-      loggerMock = {
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       store = mockStore({})
       store.dispatch(AccountActions.storageIsConnected())
     })
-
-    afterEach(() =>
-      AccountActions.__ResetDependency__('logger')
-    )
-
-    it('logs a trace message', () =>
-      assert.deepEqual(loggerMock.trace.firstCall.args, [
-        'storageConnected'
-      ])
-    )
 
     it('dispatches action {type: CONNECTED_STORAGE}', () =>
       assert.deepEqual(store.getActions()[0], {
@@ -1756,27 +1461,12 @@ describe('AccountActions', () => {
   })
 
   describe('usedIdentityAddress', () => {
-    let loggerMock
     let store
 
     beforeEach(() => {
-      loggerMock = {
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       store = mockStore({})
       store.dispatch(AccountActions.usedIdentityAddress())
     })
-
-    afterEach(() =>
-      AccountActions.__ResetDependency__('logger')
-    )
-
-    it('logs a trace message', () =>
-      assert.deepEqual(loggerMock.trace.firstCall.args, [
-        'usedIdentityAddress'
-      ])
-    )
 
     it('dispatches action {type: INCREMENT_IDENTITY_ADDRESS_INDEX}', () =>
       assert.deepEqual(store.getActions()[0], {
@@ -1786,27 +1476,12 @@ describe('AccountActions', () => {
   })
 
   describe('displayedRecoveryCode', () => {
-    let loggerMock
     let store
 
     beforeEach(() => {
-      loggerMock = {
-        trace: sinon.spy()
-      }
-      AccountActions.__Rewire__('logger', loggerMock)
       store = mockStore({})
       store.dispatch(AccountActions.displayedRecoveryCode())
     })
-
-    afterEach(() =>
-      AccountActions.__ResetDependency__('logger')
-    )
-
-    it('logs a trace message', () =>
-      assert.deepEqual(loggerMock.trace.firstCall.args, [
-        'displayedRecoveryCode'
-      ])
-    )
 
     it('dispatches action {type: VIEWED_RECOVERY_CODE}', () =>
       assert.deepEqual(store.getActions()[0], {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,8 @@ module.exports = {
     main: ['./app/js/index.js']
   },
   node: {
-    fs: 'empty'
+    fs: 'empty',
+    __filename: true
   },
   output,
   devServer: {


### PR DESCRIPTION
Slight improvements to our logging:

* Uses styling to de-emphasize the path of logging
* Uses `__filename` instead of hard coded string to get file context. Should fix a bunch of incorrect paths.
* Replaces all `logger.trace` calls with `logger.info`. You can still use `logger.trace` to print stack traces, but most uses before were not written with that intent and it spammed the console pretty bad.

Here's what the new styles look like:

<img width="368" alt="screen shot 2018-08-15 at 3 51 17 pm" src="https://user-images.githubusercontent.com/649992/44170954-eb730880-a0a6-11e8-8236-d3e86d6ffa16.png">
