### PR TITLE
Fix Lopsided Buttons

### DIFF
--- a/app/js/components/SecondaryNavBar.js
+++ b/app/js/components/SecondaryNavBar.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Link } from 'react-router'
+import * as Styled from './styled/SecondaryNavBar'
 
 const SecondaryNavLink = props => {
   const customActiveClass = props.activeClass ? props.activeClass : ''
@@ -49,95 +50,62 @@ SecondaryNavButton.propTypes = {
 const SecondaryNavBar = props => {
   const activeClass = props.activeClass ? props.activeClass : ''
   return (
-    <div className="container-fluid secondary-nav mx-auto">
-      <div className="row">
-        <div className="col text-left">
-          {props.leftButtonTitle !== undefined && (
-            props.leftIsButton ?
-              <SecondaryNavButton
-                title={props.leftButtonTitle}
-                onClick={props.onLeftButtonClick}
-                align="left"
-                isActive={props.isLeftActive}
-                activeClass={activeClass}
-                customButtonClass={props.customButtonClass}
-              />
-            :
-              <SecondaryNavLink
-                title={props.leftButtonTitle}
-                link={props.leftButtonLink}
-                align="left"
-                isActive={props.isLeftActive}
-                activeClass={activeClass}
-                customButtonClass={props.customButtonClass}
-              />
-            )}
-        </div>
-        <div className="col text-center">
-        {props.centerButtonTitle !== undefined && (
-          props.centerIsButton ?
-            <SecondaryNavLink
-              title={props.centerButtonTitle}
-              onClick={props.onCenterButtonClick}
-              align="right"
-              isActive={props.isCenterActive}
-              activeClass={activeClass}
-              customButtonClass={props.customButtonClass}
-            />
-          :
-            <SecondaryNavLink
-              title={props.centerButtonTitle}
-              link={props.centerButtonLink}
-              align="right"
-              isActive={props.isCenterActive}
-              activeClass={activeClass}
-              customButtonClass={props.customButtonClass}
-            />
-        )}
-        </div>
-        <div className="col text-right">
-        {props.rightButtonTitle !== undefined && (
-          props.rightIsButton ?
+    <Styled.Container className="container-fluid secondary-nav mx-auto">
+      <Styled.Column>
+        {props.leftButtonTitle !== undefined && (
+          props.leftIsButton ?
             <SecondaryNavButton
-              title={props.rightButtonTitle}
-              onClick={props.onRightButtonClick}
-              align="right"
-              isActive={props.isRightActive}
+              title={props.leftButtonTitle}
+              onClick={props.onLeftButtonClick}
+              isActive={props.isLeftActive}
               activeClass={activeClass}
               customButtonClass={props.customButtonClass}
             />
           :
             <SecondaryNavLink
-              title={props.rightButtonTitle}
-              link={props.rightButtonLink}
-              align="right"
-              isActive={props.isRightActive}
+              title={props.leftButtonTitle}
+              link={props.leftButtonLink}
+              isActive={props.isLeftActive}
               activeClass={activeClass}
               customButtonClass={props.customButtonClass}
             />
           )}
-        </div>
-      </div>
-    </div>
+      </Styled.Column>
+      <Styled.Column>
+      {props.rightButtonTitle !== undefined && (
+        props.rightIsButton ?
+          <SecondaryNavButton
+            title={props.rightButtonTitle}
+            onClick={props.onRightButtonClick}
+            isActive={props.isRightActive}
+            activeClass={activeClass}
+            customButtonClass={props.customButtonClass}
+          />
+        :
+          <SecondaryNavLink
+            title={props.rightButtonTitle}
+            link={props.rightButtonLink}
+            isActive={props.isRightActive}
+            activeClass={activeClass}
+            customButtonClass={props.customButtonClass}
+          />
+        )}
+      </Styled.Column>
+    </Styled.Container>
   )
 }
 
 SecondaryNavBar.propTypes = {
   title: PropTypes.string,
   leftButtonTitle: PropTypes.string,
-  centerButtonTitle: PropTypes.string,
   rightButtonTitle: PropTypes.string,
   leftButtonLink: PropTypes.string,
-  centerButtonLink: PropTypes.string,
   rightButtonLink: PropTypes.string,
   leftIsButton: PropTypes.bool,
-  centerIsButton: PropTypes.bool,
   rightIsButton: PropTypes.bool,
   onLeftButtonClick: PropTypes.func,
-  onCenterButtonClick: PropTypes.func,
   onRightButtonClick: PropTypes.func,
   isLeftActive: PropTypes.bool,
-  isCenterActive: PropTypes.bool,
   isRightActive: PropTypes.bool,
   activeClass: PropTypes.string,
   customButtonClass: PropTypes.string

--- a/app/js/components/styled/SecondaryNavBar.js
+++ b/app/js/components/styled/SecondaryNavBar.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: nowrap;
+`
+
+export const Column = styled.div`
+  flex-grow: 1;
+  margin: 0 0.5rem;
+
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:last-child {
+    text-align: right;
+    margin-right: 0;
+  }
+`

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -961,7 +961,7 @@ class DefaultProfilePage extends Component {
               </div>
 
               <div className="container-fluid p-0">
-                <div style={{ display: 'flex', justifyContent: 'space-around' }} className="m-t-10">
+                <div className="d-flex justify-content-around m-t-10">
                   <button
                     className="btn btn-outline-dark btn-pill btn-sm ml-5"
                     title={this.state.editMode ? 'Save' : 'Edit'}

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -961,38 +961,34 @@ class DefaultProfilePage extends Component {
               </div>
 
               <div className="container-fluid p-0">
-                <div className="row m-t-10 text-center">
-                  <div className="col">
+                <div style={{ display: 'flex', justifyContent: 'space-around' }} className="m-t-10">
+                  <button
+                    className="btn btn-outline-dark btn-pill btn-sm ml-5"
+                    title={this.state.editMode ? 'Save' : 'Edit'}
+                    onClick={
+                      this.state.editMode
+                        ? this.onSaveClick
+                        : this.onEditClick
+                    }
+                  >
+                    {this.state.editMode ? 'Save' : 'Edit'}
+                  </button>
+                  {this.state.editMode ? (
                     <button
-                      className="btn btn-outline-dark btn-pill btn-sm ml-5"
-                      title={this.state.editMode ? 'Save' : 'Edit'}
-                      onClick={
-                        this.state.editMode
-                          ? this.onSaveClick
-                          : this.onEditClick
-                      }
+                      className="btn btn-outline-dark btn-pill btn-sm mr-5"
+                      title="Cancel"
+                      onClick={this.onCancelClick}
                     >
-                      {this.state.editMode ? 'Save' : 'Edit'}
+                      Cancel
                     </button>
-                  </div>
-                  <div className="col">
-                    {this.state.editMode ? (
-                      <button
-                        className="btn btn-outline-dark btn-pill btn-sm mr-5"
-                        title="Cancel"
-                        onClick={this.onCancelClick}
-                      >
-                        Cancel
-                      </button>
-                    ) : (
-                      <Link
-                        className="btn btn-outline-dark btn-pill btn-sm mr-5"
-                        to="/profiles/i/all"
-                      >
-                        More
-                      </Link>
-                    )}
-                  </div>
+                  ) : (
+                    <Link
+                      className="btn btn-outline-dark btn-pill btn-sm mr-5"
+                      to="/profiles/i/all"
+                    >
+                      More
+                    </Link>
+                  )}
                 </div>
               </div>
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -2286,7 +2286,8 @@ a.modal-body {
 }
 
 .btn-wallet {
-    width: 160px;
+    width: 100%;
+    max-width: 160px;
 }
 
 .react-contextmenu {


### PR DESCRIPTION
Closes #1617. Fixes the lopsided buttons at small sizes on IDs and Wallet pages.

### Before

<img width="287" alt="screen shot 2018-08-21 at 5 29 49 pm" src="https://user-images.githubusercontent.com/649992/44430182-ea8b1c80-a567-11e8-9bdf-59daebcb1462.png">

<img width="301" alt="screen shot 2018-08-21 at 5 30 00 pm" src="https://user-images.githubusercontent.com/649992/44430186-ec54e000-a567-11e8-8d6c-660798eeb66d.png">


### After

<img width="295" alt="screen shot 2018-08-21 at 5 30 22 pm" src="https://user-images.githubusercontent.com/649992/44430194-f1199400-a567-11e8-9204-8c7a9fdffc03.png">

<img width="297" alt="screen shot 2018-08-21 at 5 30 15 pm" src="https://user-images.githubusercontent.com/649992/44430191-ef4fd080-a567-11e8-9be2-59ad7904d2e8.png">

