### PR TITLE
Fix loader on clear-auth

### DIFF
--- a/app/js/App.js
+++ b/app/js/App.js
@@ -55,9 +55,12 @@ function mapDispatchToProps(dispatch) {
 
 class AppContainer extends Component {
   static propTypes = {
+    // Own props
+    children: PropTypes.element.isRequired,
+    noHeader: PropTypes.bool,
+    // State props
     localIdentities: PropTypes.array.isRequired,
     defaultIdentity: PropTypes.number.isRequired,
-    children: PropTypes.element.isRequired,
     encryptedBackupPhrase: PropTypes.string,
     api: PropTypes.object.isRequired,
     updateApi: PropTypes.func.isRequired,
@@ -183,6 +186,7 @@ class AppContainer extends Component {
 
   componentDidMount() {
     const loader = document.getElementById('loader')
+    console.log(loader)
     if (loader && !loader.classList.contains('hidden')) {
       loader.classList.add('hidden')
     }
@@ -206,11 +210,11 @@ class AppContainer extends Component {
   }
 
   render() {
-    const { children } = this.props
+    const { children, noHeader } = this.props
     return (
-      <div className="body-main">
-        <div className="wrapper footer-padding">{ children }</div>
-        <SupportButton onClick={ this.onSupportClick }/>
+      <div className={`body-main ${noHeader ? 'no-header' : ''}`}>
+        <div className="wrapper footer-padding">{children}</div>
+        <SupportButton onClick={this.onSupportClick} />
       </div>
     )
   }

--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import { withRouter } from 'react-router'
+import App from '../App'
 
 class ClearAuthPage extends PureComponent {
   state = {
@@ -39,39 +40,41 @@ class ClearAuthPage extends PureComponent {
     const { countdown, hasAttemptedConfirm } = this.state
 
     return (
-      <div className="container-fluid">
-        <h3 className="p-t-20">Sign Out</h3>
-        <p className="p-t-20 alert alert-warning">
-          <strong>Warning:</strong> This will reset your keychain and settings
-          on this device. You’ll be able to restore your keychain, or create
-          a new one afterwards.
-          <br />
-          <br />
-          If you plan to restore your keychain, <strong>make sure you have
-          recorded your backup information.</strong> You will either need your
-          12 word secret key, or your magic recovery code and password to
-          do so.
-        </p>
-        <div className="m-t-10">
-          <button
-            className="btn btn-danger btn-block"
-            onClick={this.clearData}
-            disabled={countdown > 0}
-          >
-            {hasAttemptedConfirm ? (
-              <span>Press again to confirm</span>
-            ) : (
-              <span>Reset my device {countdown > 0 && `(${countdown})`}</span>
-            )}
+      <App noHeader>
+        <div className="container-fluid">
+          <h3 className="p-t-20">Sign Out</h3>
+          <p className="p-t-20 alert alert-warning">
+            <strong>Warning:</strong> This will reset your keychain and settings
+            on this device. You’ll be able to restore your keychain, or create
+            a new one afterwards.
+            <br />
+            <br />
+            If you plan to restore your keychain, <strong>make sure you have
+            recorded your backup information.</strong> You will either need your
+            12 word secret key, or your magic recovery code and password to
+            do so.
+          </p>
+          <div className="m-t-10">
+            <button
+              className="btn btn-danger btn-block"
+              onClick={this.clearData}
+              disabled={countdown > 0}
+            >
+              {hasAttemptedConfirm ? (
+                <span>Press again to confirm</span>
+              ) : (
+                <span>Reset my device {countdown > 0 && `(${countdown})`}</span>
+              )}
 
-          </button>
+            </button>
+          </div>
+          <div className="m-t-10">
+            <button className="btn btn-tertiary btn-block" onClick={this.cancel}>
+              Cancel
+            </button>
+          </div>
         </div>
-        <div className="m-t-10">
-          <button className="btn btn-tertiary btn-block" onClick={this.cancel}>
-            Cancel
-          </button>
-        </div>
-      </div>
+      </App>
     )
   }
 }

--- a/app/js/connect-storage/index.js
+++ b/app/js/connect-storage/index.js
@@ -6,6 +6,7 @@ import qs from 'query-string'
 import { SettingsActions } from '../account/store/settings'
 import { AppHomeWrapper, Shell } from '@blockstack/ui'
 import Modal from 'react-modal'
+import App from '../App'
 
 class ConnectStoragePage extends React.Component {
   state = {
@@ -29,7 +30,7 @@ class ConnectStoragePage extends React.Component {
   render() {
     const { error } = this.state
     return (
-      <React.Fragment>
+      <App>
         <Modal
           className="container-fluid"
           shouldCloseOnOverlayClick={false}
@@ -46,7 +47,7 @@ class ConnectStoragePage extends React.Component {
           )}
         </Modal>
         <AppHomeWrapper />
-      </React.Fragment>
+      </App>
     )
   }
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -6,6 +6,9 @@
     height: 100%;
     padding-top: 100px;
 }
+.body-main.no-header {
+  padding-top: 0;
+}
 
 .body-landing {
     width: 100%;


### PR DESCRIPTION
Closes #1632. Wraps pages that weren't wrapped in `<App />` so that they get the same behavior as other pages, which includes dismissing the loader.

### Steps to Test

* Load `/clear-auth`, confirm it shows.