### PR TITLE
Fix image path in Registration Submitted View

### DIFF
--- a/app/js/profiles/components/registration/RegistrationSubmittedView.js
+++ b/app/js/profiles/components/registration/RegistrationSubmittedView.js
@@ -19,7 +19,7 @@ const RegistrationSubmittedView = (props) => {
         {bodyContent}
         <img
           role="presentation"
-          src="/images/blockstack-logo-vertical.svg"
+          src="/static/images/blockstack-logo-vertical.svg"
           className="m-b-20"
           style={{ width: '210px', display: 'block', marginRight: 'auto', marginLeft: 'auto' }}
         />


### PR DESCRIPTION
This PR
* fixes the broken path for the image in confirmation view after the user submitted a registration name.

Steps to see the broken path
1. submit a registration for a new username
1. See something like below
![bildschirmfoto von 2018-10-17 08-54-36](https://user-images.githubusercontent.com/1449049/47067916-2569a380-d1eb-11e8-88cb-197e84e8b786.png)
