### PR TITLE
Handle case where profile is missing for restored identity

### DIFF
--- a/app/js/profiles/store/identity/actions.js
+++ b/app/js/profiles/store/identity/actions.js
@@ -394,6 +394,7 @@ function refreshIdentities(
                         `refreshIdentities: resolveZoneFileToProfile for ${nameOwned} error`,
                         error
                       )
+                      dispatch(updateProfile(index, DEFAULT_PROFILE, zoneFile))
                       resolve()
                       return Promise.resolve()
                     })


### PR DESCRIPTION
This fixes the underlying cause for the behavior experienced in #1717 -- the profile writing logic in the browser depends on the `identity.zonefile` entry being filled, which it wasn't in the case of profiles that fail to resolve (even though the zonefile resolves).

We may want to do something more than just this one-line fix though, such as:

1. pre-emptively writing the DEFAULT_PROFILE to the profileURL in the zone file location
2. calling refreshIdentities in the login flow if the identity.zoneFile field is null (this would allow such users to login correctly without having to go through the restore process again). Roughly around here: https://github.com/blockstack/blockstack-browser/blob/84ec3e261beaad57b844c37eb405f1649484d94a/app/js/auth/index.js#L218