### PR TITLE
Fixes the profile.json URL contained in our `authResponse`

### DIFF
--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -230,7 +230,7 @@ class AuthPage extends React.Component {
 
       const gaiaBucketAddress = nextProps.identityKeypairs[0].address
       const identityAddress = nextProps.identityKeypairs[identityIndex].address
-      const gaiaUrlBase = 'https://gaia.blockstack.org/hub'
+      const gaiaUrlBase = nextProps.api.gaiaHubConfig.url_prefix
 
       if (!profileUrlPromise) {
         profileUrlPromise = fetchProfileLocations(


### PR DESCRIPTION
Fix for #1763 