### PR TITLE
Remove the ability to scan QR codes

### DIFF
--- a/app/js/sign-in/index.js
+++ b/app/js/sign-in/index.js
@@ -124,7 +124,7 @@ class SignIn extends React.Component {
       })
     })
 
-  backToSignUp = () => browserHistory.push({ pathname: '/sign-up' })
+  backToSignUp = () => browserHistory.push(`/sign-up${document.location.search}`)
 
   isKeyEncrypted = key =>
     import(/* webpackChunkName: 'bip39' */ 'bip39').then(

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -89,7 +89,6 @@ export default class InitialSignInScreen extends React.PureComponent {
       })
     }
 
-
     const screen = {
       title: {
         children: 'Enter Secret Recovery Key or Magic Recovery Code'

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -70,6 +70,25 @@ export default class InitialSignInScreen extends React.PureComponent {
   render() {
     const { next, value, ...rest } = this.props
     const { isScanning, scanError } = this.state
+    const isNative = document.location.search.indexOf('client=ios_secure') !== -1
+
+    const actionItems = [
+      {
+        label: 'Sign In',
+        primary: true,
+        icon: 'ArrowRightIcon',
+        type: 'submit'
+      }
+    ]
+
+    if (!isNative) {
+      actionItems.unshift({
+        label: 'Scan',
+        icon: 'QrcodeIcon',
+        onClick: this.startScanning
+      })
+    }
+
 
     const screen = {
       title: {
@@ -94,14 +113,7 @@ export default class InitialSignInScreen extends React.PureComponent {
           ],
           actions: {
             split: true,
-            items: [
-              {
-                label: 'Sign In',
-                primary: true,
-                icon: 'ArrowRightIcon',
-                type: 'submit'
-              }
-            ]
+            items: actionItems
           }
         },
         children: (

--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -96,11 +96,6 @@ export default class InitialSignInScreen extends React.PureComponent {
             split: true,
             items: [
               {
-                label: 'Scan',
-                icon: 'QrcodeIcon',
-                onClick: this.startScanning
-              },
-              {
                 label: 'Sign In',
                 primary: true,
                 icon: 'ArrowRightIcon',

--- a/app/js/sign-up/views/_initial.js
+++ b/app/js/sign-up/views/_initial.js
@@ -8,6 +8,11 @@ import { ShellScreen, Type } from '@blockstack/ui'
 import { Flex } from '@components/ui/components/primitives'
 import PropTypes from 'prop-types'
 const InitialScreen = ({ next, ...rest }) => {
+  // console.log(document.location.href)
+  let client = 'browser'
+  if (document.location.search.indexOf('ios_secure') !== -1) {
+    client = 'ios_secure'
+  }
   const props = {
     content: {
       grow: 1,
@@ -34,7 +39,7 @@ const InitialScreen = ({ next, ...rest }) => {
         },
         {
           label: 'Sign in with an existing ID',
-          to: '/sign-in'
+          to: `/sign-in?client=${client}`
         }
       ]
     }


### PR DESCRIPTION
Apparently, scanning QR codes has never worked in native iOS apps, due to the way they're set up to use Safari. It's currently blocking Stealthy (discussed in #1790), so the easiest solution for now is to remove the button that lets you scan.

I believe we'd like to push this hotfix to the hosted browser, so that Stealthy can get past iOS approvers.

(cc @prabhaav for visibility)

QA process: view the netlify preview. Click 'sign in with an existing ID'. There should be no 'scan' button on the bottom of that modal. Everything else should work as normal.