### PR TITLE
Fix overwriting of stale profiles 

### DIFF
--- a/app/js/auth/views/initial.js
+++ b/app/js/auth/views/initial.js
@@ -6,7 +6,13 @@ const basicInfo = 'read your basic info'
 const readEmail = 'read your email address'
 const publishData = 'publish data stored for this app'
 
-const Accounts = ({ list, handleClick, processing, selectedIndex }) => {
+const Accounts = ({ list, handleClick, processing, refreshingIdentities, selectedIndex }) => {
+  let loadingMessage = null
+  if (processing) {
+    loadingMessage = 'Signing in...'
+  } else if (refreshingIdentities) {
+    loadingMessage = 'Loading...'
+  }
   if (list.length) {
     return list.map(({ username, ownerAddress, profile, ...account }, i) => {
       const person = new Person(profile)
@@ -17,9 +23,9 @@ const Accounts = ({ list, handleClick, processing, selectedIndex }) => {
           id={ownerAddress}
           avatarUrl={person.avatarUrl()}
           onClick={() => handleClick(i)}
-          loading={processing && i === selectedIndex}
-          disabled={processing}
-          placeholder="Signing in..."
+          loading={refreshingIdentities || (processing && i === selectedIndex)}
+          disabled={refreshingIdentities || processing}
+          placeholder={loadingMessage}
           style={{ transform: 'translate3d(0,0,0)' }}
           hideID
         />
@@ -75,6 +81,7 @@ const InitialScreen = ({
   processing,
   selectedIndex,
   login,
+  refreshingIdentities,
   ...rest
 }) => {
   const generatePermissionsList = () => {
@@ -108,6 +115,7 @@ const InitialScreen = ({
               list={accounts}
               handleClick={login}
               processing={processing}
+              refreshingIdentities={refreshingIdentities}
               selectedIndex={selectedIndex}
             />
           </Buttons>
@@ -134,13 +142,15 @@ InitialScreen.propTypes = {
   permissions: PropTypes.array,
   processing: PropTypes.bool,
   selectedIndex: PropTypes.number,
-  login: PropTypes.func
+  login: PropTypes.func,
+  refreshingIdentities: PropTypes.bool
 }
 Accounts.propTypes = {
   list: PropTypes.array.isRequired,
   handleClick: PropTypes.func,
   processing: PropTypes.bool,
-  selectedIndex: PropTypes.number
+  selectedIndex: PropTypes.number,
+  refreshingIdentities: PropTypes.bool
 }
 
 PermissionsList.propTypes = {


### PR DESCRIPTION
This is a fix for #1745.

The gist of the bug is that your profile is only cached in your local browser. Thus, if you're logging in with multiple devices, you can overwrite your profile.json with stale state during a log in. Specifically, what gets effected is your `apps` object.

How to QA this:

1. Clear auth in both localhost:3000 and localhost:8888 (it just makes it easier, in case you've already logged into a lot of apps)
1. Turn on development mode, using this branch
2. Log into a multiplayer app (like Graphite), and make a new profile or log in with a profile that's never used Graphite
3. View your profile.json file in Gaia, and make sure that graphite was added to the `apps` object.
4. Turn off development mode. Don't do anything that may trigger a refreshing of identities (like looking at the `IDs` page)
5. Log into a multiplayer app (like Travelstack), and restore with the account you just made.
6. Look at your profile.json, and it should have both Travelstack and Graphite
7. Turn on development mode
8. Log into a third multiplayer app (like dpage.io)
9. Look at your profile.json again. It should have all 3 apps installed.

If you did this without this branch, your profile would only have 2 apps installed (dpage and graphite)

This PR should also fix the issue that you don't see your username when you restore your profile during login to an app.