### PR TITLE
Remove MacOS keychain usage & prompts

### DIFF
--- a/native/macos/Blockstack/Blockstack/AppDelegate.swift
+++ b/native/macos/Blockstack/Blockstack/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         os_log("applicationDidFinishLaunching: %{public}@", log: log, type: .default, blockstackDataURL().absoluteString)
 
-        portalLogServer = PortalLogServer.init(port: UInt16(logServerPort), password: self.createOrRetrieveCoreWalletPassword())
+        // portalLogServer = PortalLogServer.init(port: UInt16(logServerPort), password: self.createOrRetrieveCoreWalletPassword())
 
         // register initial user default values
         registerInitialUserDefaults()
@@ -455,6 +455,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if(isRegTestModeEnabled && !isRegTestModeChanging) {
             return regTestCoreAPIPassword
         }
+
+        return generatePassword()
 
         let serviceNameData = (keychainServiceName as NSString).utf8String
         let accountNameData = (keychainAccountName as NSString).utf8String


### PR DESCRIPTION
When running unsigned test builds of Blockstack.app, alarming keychain password prompts are shown several times. After talking with @jcnelson it looks like we aren't using any of that code anymore. 

This PR:  
* Disabled the obsolete swift code for reading unused core wallet password.
* Disabled spawning the portal log server.

I made as little changes as possible, not wanting to break anything. Essentially just commented out and short circuited a couple lines. There is probably more cleanup work that can be done here. 