### PR TITLE
Fixes `/clear-auth` endpoint

### DIFF
--- a/app/js/clear-auth/index.js
+++ b/app/js/clear-auth/index.js
@@ -25,7 +25,7 @@ class ClearAuthPage extends PureComponent {
   clearData = () => {
     if (this.state.hasAttemptedConfirm) {
       localStorage.clear()
-      window.location = `${this.props.location.query.redirect_uri}://?authCleared=1`
+      window.location = '/?authCleared=1'
     }
     else {
       this.setState({ hasAttemptedConfirm: true })


### PR DESCRIPTION
When you clicked to confirm, it did actually reset your storage, but wasn't redirecting you properly. It made it seem like nothing happened.