### PR TITLE
Tests for validating backwards compatibility in blockstack.js v19

### DIFF
--- a/test-e2e/auth/sign-in.js
+++ b/test-e2e/auth/sign-in.js
@@ -71,8 +71,6 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
       await driver.switchTo().window(windowHandle);
       await driver.sleep(4000);
     }
-    // Failed attempt to close protocol handler prompt on chrome:
-    // await driver.actions({ bridge: true }).sendKeys(Key.ESCAPE).perform();
   });
 
   step('wait for auth page to load', async () => {
@@ -87,10 +85,9 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
     await driver.el(By.xpath('//div[contains(.,"Hello, Alice")]'));
   });
 
+  let userData;
   step('validate blockstack user data', async () => {
-    const userData = await driver.executeScript(`
-      return blockstack.loadUserData();
-    `);
+    userData = await driver.executeScript(`return blockstack.loadUserData()`);
     expect(userData.appPrivateKey).to.have.lengthOf(64);
     expect(userData.decentralizedID).to.equal("did:btc-addr:1NDsatzAEqrErxkB1osfJXouADgrHXuDs1");
     expect(userData.hubUrl).to.equal("https://hub.blockstack.org");
@@ -100,42 +97,80 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
     expect(userData.profile.api.gaiaHubConfig.url_prefix).to.equal("https://gaia.blockstack.org/hub/");
   });
 
+  step('validate blockstack.encryptContent(...) & blockstack.decryptContent(...) with account key', async () => {
+    const exampleData = "example data";
+    const cipher = await driver.executeScript(`return blockstack.encryptContent(arguments[0])`, exampleData);
+    expect(JSON.parse(cipher)["wasString"]).to.be.true;
+    const decrypted = await driver.executeScript(`return blockstack.decryptContent(arguments[0])`, cipher);
+    expect(decrypted).to.equal(exampleData);
+  });
+
+  step('validate blockstack.encryptContent(...) & blockstack.decryptContent(...) with specified keys', async () => {
+    const publicKey = "0420a5c99852eae2e51d2638564cb4eb1066ac0126a534b25c31a9386b0d97c55abf77ba60dd029be0414d082a2acbc1477ebb6e028d37bbe16c354532e9de61dc";
+    const privateKey = "80e626ad4bf501f58be7a1c4763a4c544bb83cc334ebee122321e8f30e41770f";
+    const exampleData = "example data";
+    const cipher = await driver.executeScript(
+      `return blockstack.encryptContent(arguments[0], arguments[1])`, 
+      exampleData, { publicKey: publicKey });
+    expect(JSON.parse(cipher)["wasString"]).to.be.true;
+    const decrypted = await driver.executeScript(
+      `return blockstack.decryptContent(arguments[0], arguments[1])`, 
+      cipher, { privateKey: privateKey });
+    expect(decrypted).to.equal(exampleData);
+  });
+
+  step('validate blockstack.getAppBucketUrl(...)', async () => {
+    const appBucketUrl = await driver.executePromise(
+      `blockstack.getAppBucketUrl(arguments[0], arguments[1])`, 
+      userData.hubUrl, 
+      userData.appPrivateKey);
+    expect(appBucketUrl).to.match(new RegExp("https://gaia.blockstack.org/hub/[a-zA-Z0-9]{34}/"));
+  });
+
   let gaiaFileData;
 
   step('validate blockstack.putFile(...)', async () => {
-    // Get some random data to write.
     gaiaFileData = helpers.getRandomString(20);
-
-    // blockstack.putFile(...)
-    const putFileError = await driver.executeAsyncScript(`
-      var cb = arguments[arguments.length - 1];
-      blockstack.putFile("/hello.txt", "${gaiaFileData}").then(() => {
-        cb();
-      }).catch((error) => {
-        cb(error.toString());
-      });
-    `);
-    if (putFileError) {
-      throw new Error(`Error performing "blockstack.putFile(...)": ${putFileError}`);
-    }
+    const putFileResult = await driver.executePromise(
+      `blockstack.putFile("/hello.txt", arguments[0])`, 
+      gaiaFileData);
+    expect(putFileResult).to.match(new RegExp("https://gaia.blockstack.org/hub/[a-zA-Z0-9]{34}//hello.txt"));
   });
 
   step('validate blockstack.getFile(...)', async () => {
-    // blockstack.getFile(...)
-    const [ getFileResult, getFileError ] = await driver.executeAsyncScript(`
-      var cb = arguments[arguments.length - 1];
-      blockstack.getFile("/hello.txt").then((fileContents) => {
-        cb([fileContents, null]);
-      }).catch((error) => {
-        cb([null, error.toString()]);
-      });
-    `);
-    if (getFileError) {
-      throw new Error(`Error performing "blockstack.getFile(...)": ${getFileError}`);
-    }
-
-    // Verify file contents.
+    const getFileResult = await driver.executePromise(`blockstack.getFile("/hello.txt")`);
     expect(getFileResult).to.equal(gaiaFileData);
+  });
+
+  step('validate blockstack.getUserAppFileUrl(...)', async () => {
+    const userAppFileUrl = await driver.executePromise(
+      `blockstack.getUserAppFileUrl(arguments[0], arguments[1], arguments[2])`, 
+      'public/1547742731687.json', 
+      'mattlittle_test1.id.blockstack', 
+      'https://app.graphitedocs.com');
+    expect(userAppFileUrl).to.equal("https://gaia.blockstack.org/hub/18e3diVDsRfq2ckqS56wYw9mQhS4kxC15F/public/1547742731687.json");
+  });
+
+  step('validate blockstack.getFile(...) with multi-player storage', async () => {
+    const getFileResult = await driver.executePromise(
+      `blockstack.getFile(arguments[0], arguments[1])`, 
+      'public/1547742731687.json', { 
+        username: 'mattlittle_test1.id.blockstack',
+        app: 'https://app.graphitedocs.com',
+        decrypt: false
+      });
+    // Sanity check on content..
+    const resultJson = JSON.parse(getFileResult);
+    expect(resultJson["shared"]).to.equal("2/21/2019");
+  });
+
+  step('validate blockstack.signUserOut(...)', async () => {
+    const redirectUrl = `http://${loopbackHost}:${helloServerPort}/?some=param`;
+    await driver.executeScript(`blockstack.signUserOut(arguments[0])`, redirectUrl);
+    await driver.sleep(50);
+    await driver.el(By.css('#signin-button'));
+    const windowLocation = await driver.getCurrentUrl();
+    expect(windowLocation).to.equal(redirectUrl);
   });
 
 });

--- a/test-e2e/auth/sign-in.js
+++ b/test-e2e/auth/sign-in.js
@@ -173,6 +173,13 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
     expect(windowLocation).to.equal(redirectUrl);
   });
 
+  step('validate localStorage user data is been cleared', async () => {
+    const localStorageRedux = await driver.executeScript(`return window.localStorage.getItem('redux')`);
+    const localStorageStateVer = await driver.executeScript(`return window.localStorage.getItem('BLOCKSTACK_STATE_VERSION')`);
+    expect(localStorageRedux).to.not.exist;
+    expect(localStorageStateVer).to.not.exist;
+  });
+
 });
 
 

--- a/test-e2e/auth/sign-in.js
+++ b/test-e2e/auth/sign-in.js
@@ -174,10 +174,10 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
   });
 
   step('validate localStorage user data is been cleared', async () => {
-    const localStorageRedux = await driver.executeScript(`return window.localStorage.getItem('redux')`);
-    const localStorageStateVer = await driver.executeScript(`return window.localStorage.getItem('BLOCKSTACK_STATE_VERSION')`);
-    expect(localStorageRedux).to.not.exist;
-    expect(localStorageStateVer).to.not.exist;
+    const localStorageSession = await driver.executeScript(`return window.localStorage.getItem('blockstack-session')`);
+    const sessionJson = JSON.parse(localStorageSession);
+    const userData = sessionJson['userData'];
+    expect(userData).to.not.exist;
   });
 
 });

--- a/test-e2e/auth/sign-in.js
+++ b/test-e2e/auth/sign-in.js
@@ -175,9 +175,14 @@ createTestSuites('login-to-hello-blockstack-app', ({driver, browserHostUrl, loop
 
   step('validate localStorage user data is been cleared', async () => {
     const localStorageSession = await driver.executeScript(`return window.localStorage.getItem('blockstack-session')`);
-    const sessionJson = JSON.parse(localStorageSession);
-    const userData = sessionJson['userData'];
-    expect(userData).to.not.exist;
+    if (localStorageSession) {
+      const sessionJson = JSON.parse(localStorageSession);
+      const userData = sessionJson['userData'];
+      expect(userData).to.not.exist;
+    }
+    else {
+      expect(localStorageSession).to.not.exist;
+    }
   });
 
 });

--- a/test-e2e/utils/ExtendedWebDriver.js
+++ b/test-e2e/utils/ExtendedWebDriver.js
@@ -27,6 +27,25 @@ class ExtendedWebDriver extends WebDriver {
   }
 
   /**
+   * 
+   * @param {string} script A javascript expression that evaluates to a promise.
+   * @param {...any} args
+   * @returns {any} The evaluated promise result, if any.
+   */
+  async executePromise(script, ...args) {
+    const [error, result] = await this.driver.executeAsyncScript(`
+      var callback = arguments[arguments.length - 1];
+      ${script}
+        .then(result => callback([null, result]))
+        .catch(error => callback([error.toString(), null]));
+    `, ...args);
+    if (error) {
+      throw new Error(error);
+    }
+    return result;
+  }
+
+  /**
    * Retries a given function until the given time has elapsed. 
    * @param {(Promise<any>|(function():any)} func
    * @param {number} timeout - milliseconds to continue re-trying execution of a failing function.

--- a/test-e2e/utils/config.js
+++ b/test-e2e/utils/config.js
@@ -43,7 +43,7 @@ const config = {
   // Check environment vars for BrowserStack usage settings.
   const USE_BROWSERSTACK = 'USE_BROWSERSTACK';
   const BROWSERSTACK_AUTH = 'BROWSERSTACK_AUTH';
-  config.browserStack.enabled = process.env[USE_BROWSERSTACK] && process.env[USE_BROWSERSTACK] !== 'false';
+  config.browserStack.enabled = !helpers.isFalsy(process.env[USE_BROWSERSTACK]);
   if (config.browserStack.enabled) {
     config.browserStack.hubUrl = BROWSERSTACK_HUB_URL;
     const browserstackAuth = process.env[BROWSERSTACK_AUTH];

--- a/test-e2e/utils/helpers.js
+++ b/test-e2e/utils/helpers.js
@@ -1,6 +1,10 @@
 
 module.exports = class Helpers {
 
+  static isFalsy(val) {
+    return !val || /^\s*(false|0|off|no)\s*$/i.test(val);
+  }
+
   static timeout(ms) {
     return new Promise(resolve => setTimeout(() => resolve(), ms));
   }


### PR DESCRIPTION
Tests for more blockstack.js APIs for ensuring https://github.com/blockstack/blockstack.js/pull/542 remains backwards compatible. 

(Note: this is not an exhaustive list of tests for all public blockstack.js methods & parameters)

All tests are currently passing when running against the v19 PR when running 
```
npm install blockstack@blockstack/blockstack.js#feature/storage-strategies
TEST_E2E_GREP=login-to-hello-blockstack-app npm run test-e2e:browserstack
```