### PR TITLE
Fix recovery code validation with missing base64 padding char

### DIFF
--- a/app/js/sign-in/views/_initial.js
+++ b/app/js/sign-in/views/_initial.js
@@ -13,7 +13,7 @@ const validateInput = async value =>
       return true
     }
     // Base64 encoded encrypted phrase
-    return /[a-zA-Z0-9+/]=$/.test(value)
+    return /[a-zA-Z0-9+/]=?$/.test(value)
   })
 
 const validationSchema = Yup.object({

--- a/app/js/utils/encryption-utils.js
+++ b/app/js/utils/encryption-utils.js
@@ -73,8 +73,8 @@ export function validateAndCleanRecoveryInput(input) {
   let cleanedEncrypted = cleaned.replace(/\s/gm, '')
 
   if (
-    cleanedEncrypted.length === 107 &&
-    cleanedEncrypted.indexOf('=') !== 106
+    /^[a-zA-Z0-9\+\/]+=?$/.test(cleanedEncrypted) &&
+    cleanedEncrypted.slice(-1) !== '='
   ) {
     // Append possibly missing equals sign padding
     logger.debug('Encrypted Phrase needs an `=` at the end.')


### PR DESCRIPTION
Fixes the validation for recovery codes that are 128 characters long and missing the base64 `=` padding char. 