### PR TITLE
Persist email address in localStorage

### DIFF
--- a/app/js/account/store/account/reducer.js
+++ b/app/js/account/store/account/reducer.js
@@ -5,7 +5,7 @@ import { getBitcoinAddressNode } from '@utils'
 const initialState = {
   accountCreated: false, // persist
   promptedForEmail: false, // persist
-  email: null,
+  email: null, // persist
   encryptedBackupPhrase: null, // persist
   identityAccount: {
     addresses: [],

--- a/app/js/store/reducers.js
+++ b/app/js/store/reducers.js
@@ -70,6 +70,7 @@ function reducer(state: any, action: any) {
       },
       account: Object.assign({}, initialState.account, {
         promptedForEmail: state.account.promptedForEmail,
+        email: state.account.email,
         viewedRecoveryCode: state.account.viewedRecoveryCode,
         connectedStorageAtLeastOnce: state.account.connectedStorageAtLeastOnce
       })
@@ -84,6 +85,7 @@ function reducer(state: any, action: any) {
       },
       account: Object.assign({}, initialState.account, {
         promptedForEmail: state.account.promptedForEmail,
+        email: state.account.email,
         viewedRecoveryCode: state.account.viewedRecoveryCode,
         connectedStorageAtLeastOnce: state.account.connectedStorageAtLeastOnce
       })


### PR DESCRIPTION
Email address was not being persisted in the redux state during the browser upgrade transition (where it shows "browser has updated, enter your password"). 

For the email scope issue:
https://github.com/blockstack/blockstack-browser/issues/1780
https://github.com/blockstack/blockstack-browser/issues/1853

Also note: the email address returned in the token payload is not easy to access via blockstack.js - this PR addresses that https://github.com/blockstack/blockstack.js/pull/623 