### PR TITLE
Appveyor sign build on next branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,23 @@ build_script:
 
     copy native\windows\BlockstackSetup\bin\Release\en-us\BlockstackSetup.msi .\
 
-    IF "%APPVEYOR_REPO_BRANCH%"=="master" ( powershell -Command "& @((Resolve-Path -Path '%ProgramFiles(x86)%\Windows Kits\10\bin\10*\x86\signtool.exe').Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi" )
+    IF "%sign_msi%"=="true" ( powershell -Command "& @((Resolve-Path -Path '%ProgramFiles(x86)%\Windows Kits\10\bin\10*\x86\signtool.exe').Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi" )
 artifacts:
 - path: BlockstackSetup.msi
 cache:
   - node_modules
   - wix311.exe
+
+
+for:
+
+# override settings for `master` and `next` branches to perform signing
+-
+  branches:
+    only:
+      - master
+      - next
+
+  environment:
+    sign_msi: true
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,12 @@ build_script:
 
     copy native\windows\BlockstackSetup\bin\Release\en-us\BlockstackSetup.msi .\
 
-    IF "%sign_msi%"=="true" ( powershell -Command "& @((Resolve-Path -Path '%ProgramFiles(x86)%\Windows Kits\10\bin\10*\x86\signtool.exe').Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi" )
+    IF "%sign_msi%"=="true" ( 
+      ECHO signing MSI file 
+      powershell -Command "& @((Resolve-Path -Path '%ProgramFiles(x86)%\Windows Kits\10\bin\10*\x86\signtool.exe').Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi" 
+      ) ELSE (
+        ECHO skipping signing MSI file
+      )
 artifacts:
 - path: BlockstackSetup.msi
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,21 +15,15 @@ install:
 
     npm i
 build_script:
-- cmd: |-
+- cmd: >-
     npm run win32
 
     copy native\windows\BlockstackSetup\bin\Release\en-us\BlockstackSetup.msi .\
 
-    IF "%sign_msi%"=="true" ( 
-      ECHO signing MSI file 
-      powershell -Command "& @((Resolve-Path -Path '%ProgramFiles(x86)%\Windows Kits\10\bin\10*\x86\signtool.exe').Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi" 
-      ) ELSE (
-        ECHO skipping signing MSI file
-      )
 artifacts:
 - path: BlockstackSetup.msi
 cache:
-  - node_modules
+  - node_modules -> package.json
   - wix311.exe
 
 
@@ -42,6 +36,14 @@ for:
       - master
       - next
 
-  environment:
-    sign_msi: true
+  build_script:
+  - ps: Write-Host 'signing MSI file'
+  - ps: (& @((Resolve-Path -Path "${Env:ProgramFiles(x86)}\Windows Kits\10\bin\10*\x86\signtool.exe").Path)[0] sign /t http://timestamp.verisign.com/scripts/timstamp.dll /n Blockstack /f signcertfile.pfx BlockstackSetup.msi)
 
+-
+  branches:
+    except:
+      - master
+      - next
+  build_script:
+  - ps: Write-Host 'skipping signing MSI file'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 
     npm i
 build_script:
-- cmd: >-
+- cmd: |-
     npm run win32
 
     copy native\windows\BlockstackSetup\bin\Release\en-us\BlockstackSetup.msi .\


### PR DESCRIPTION
Updated appveyor script to perform signing on both the `master` and `next` branches. 

I confirmed that this is behaving correctly when not on those branches, but need to merge into `next` or `master` to test if the YAML + powershell changes are working correctly. 