### PR TITLE
Handle relative icon urls in manifest

### DIFF
--- a/app/js/components/ui/containers/headers.js
+++ b/app/js/components/ui/containers/headers.js
@@ -64,6 +64,10 @@ const Header = ({
 }) => {
   const renderBugs = () => {
     if (app) {
+      const appIcon = app.manifestURI
+        ? new URL(app.icon, app.manifestURI).toString()
+        : app.icon
+
       return (
         <Bugs>
           <BlockstackBug invert={invert} size={28} />
@@ -71,7 +75,7 @@ const Header = ({
             <ChevronDoubleRightIcon color={'rgba(39, 16, 51, 0.2)'} size={18} />
           </StyledBug.Arrows>
           <Bug size={28} title={app.name}>
-            <img src={app.icon} alt={app.name} />
+            <img src={appIcon} alt={app.name} />
           </Bug>
         </Bugs>
       )


### PR DESCRIPTION
This PR
* uses the manifest url (if available) to resolve a relative icon url retrieved from the app manifest

* fixes #1783 

This only comes into effect after https://github.com/blockstack/blockstack.js/pull/629 is merged and the new version of blockstack.js is used - until then app developers need to specify absolute icon urls in their manifest.

Re image src (from MDN: https://developer.mozilla.org/en-US/docs/Web/Manifest#icons)
`src`     The path to the image file. If src is a relative URL, the base URL will be the URL of the manifest.
