### PR TITLE
Fix onboarding button being covered on mobile screens

### DIFF
--- a/app/js/components/ui/containers/profile.js
+++ b/app/js/components/ui/containers/profile.js
@@ -19,7 +19,8 @@ export const Title = ({ user, ...p }) => (
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis'
       }}
-      width='100%'
+      m={0}
+      width="100%"
       maxWidth={['calc(100% - 60px)', 'calc(100% - 40px)']}
     >
       {user.username && user.username.includes('.')
@@ -35,11 +36,11 @@ export const Suffix = ({ user, ...p }) => (
 )
 
 export const Line = p => (
-  <Flex {...p} alignItems="center" justifyContent="center" my={4}>
+  <Flex {...p} alignItems="center" justifyContent="center" my={3}>
     <Box width={85} height={'2px'} bg="whitesmoke" />
   </Flex>
 )
-export const ProfileScreen = ({ children, user, ...p }) => {
+export const ProfileScreen = ({ children, user, hideLine }) => {
   const avatarUrl =
     user && user.profile && user.profile.image && user.profile.image.length
       ? user.profile.image[0].contentUrl
@@ -50,6 +51,7 @@ export const ProfileScreen = ({ children, user, ...p }) => {
       flexDirection="column"
       alignItems="center"
       justifyContent="center"
+      width={1}
       style={{
         flexGrow: 1
       }}
@@ -57,11 +59,11 @@ export const ProfileScreen = ({ children, user, ...p }) => {
       <UserAvatar textSize={24} size={85} avatarUrl={avatarUrl} {...user} />
       {user && user.username ? (
         <>
-          <Title user={user} pt={4} />
+          <Title user={user} pt={3} />
           <Suffix user={user} />
         </>
       ) : null}
-      <Line />
+      {hideLine ? null : <Line />}
       <Box textAlign="center">{children}</Box>
     </Flex>
   )

--- a/app/js/sign-up/views/_success.js
+++ b/app/js/sign-up/views/_success.js
@@ -4,10 +4,10 @@
  * This screen welcomes the new user and shows their username / ID
  */
 import React from 'react'
-import { ShellScreen, Type } from '@blockstack/ui'
+import { ShellScreen, Type, Button } from '@blockstack/ui'
 import PropTypes from 'prop-types'
-import { ProfileScreen } from '@components/ui/containers/profile'
-import { Flex } from '@components/ui/components/primitives'
+import { ProfileScreen, Line } from '@components/ui/containers/profile'
+import { Flex, Box } from '@components/ui/components/primitives'
 
 const Success = ({
   finish,
@@ -27,49 +27,27 @@ const Success = ({
     : null
 
   const props = {
-    title: {
-      children: (
-        <ProfileScreen 
-          user={user} 
-          justifyContent="center"
-          alignItems="center"
-          style={{
-            justifyContent: "center",
-            alignItems: "center"
-          }}
-        >
-        </ProfileScreen>
-      )
-    },
     content: {
       grow: 1,
-      form: {
-        fields: [],
-        actions: {
-          items: [
-            {
-              label: (
-                <>
-                  Go to {app && app.name ? app.name : 'Blockstack'}
-                </>
-              ),
-              primary: true,
-              onClick: () => finish()
-            }
-          ]
-        }
-      },
       children: (
-        <Flex
-          justifyContent="center"
-          alignItems="center"
-        >
-          <Type.p>
-            Your ID is ready and we sent recovery instructions to your email.
-            You can also view your{' '}
-            <Type.a onClick={() => goToRecovery()}>Secret Recovery Key</Type.a>.
-          </Type.p>
-        </Flex>
+        <ProfileScreen hideLine user={user}>
+          <Box pt={3} pb={2}>
+            <Button primary onClick={finish}>
+              <>Go to {app && app.name ? app.name : 'Blockstack'}</>
+            </Button>
+          </Box>
+          <Line />
+          <Flex justifyContent="center" alignItems="center">
+            <Type.p>
+              Your ID is ready and we sent recovery instructions to your email.
+              You can also view your{' '}
+              <Type.a onClick={() => goToRecovery()}>
+                Secret Recovery Key
+              </Type.a>
+              .
+            </Type.p>
+          </Flex>
+        </ProfileScreen>
       )
     }
   }

--- a/app/js/sign-up/views/_success.js
+++ b/app/js/sign-up/views/_success.js
@@ -7,6 +7,7 @@ import React from 'react'
 import { ShellScreen, Type } from '@blockstack/ui'
 import PropTypes from 'prop-types'
 import { ProfileScreen } from '@components/ui/containers/profile'
+import { Flex } from '@components/ui/components/primitives'
 
 const Success = ({
   finish,
@@ -26,30 +27,50 @@ const Success = ({
     : null
 
   const props = {
+    title: {
+      children: (
+        <ProfileScreen 
+          user={user} 
+          justifyContent="center"
+          alignItems="center"
+          style={{
+            justifyContent: "center",
+            alignItems: "center"
+          }}
+        >
+        </ProfileScreen>
+      )
+    },
     content: {
       grow: 1,
+      form: {
+        fields: [],
+        actions: {
+          items: [
+            {
+              label: (
+                <>
+                  Go to {app && app.name ? app.name : 'Blockstack'}
+                </>
+              ),
+              primary: true,
+              onClick: () => finish()
+            }
+          ]
+        }
+      },
       children: (
-        <ProfileScreen user={user}>
+        <Flex
+          justifyContent="center"
+          alignItems="center"
+        >
           <Type.p>
             Your ID is ready and we sent recovery instructions to your email.
             You can also view your{' '}
             <Type.a onClick={() => goToRecovery()}>Secret Recovery Key</Type.a>.
           </Type.p>
-        </ProfileScreen>
+        </Flex>
       )
-    },
-    actions: {
-      items: [
-        {
-          label: (
-            <>
-              Go to {app && app.name ? app.name : 'Blockstack'}
-            </>
-          ),
-          primary: true,
-          onClick: () => finish()
-        }
-      ]
     }
   }
   return <ShellScreen {...rest} {...props} />


### PR DESCRIPTION
Changes the UI of the last onboarding screen so that the button to continue isn't covered up on mobile screens.

![image](https://user-images.githubusercontent.com/29081231/54706954-796c1180-4b16-11e9-980e-19d3c70f84c8.png)


Related issue: https://github.com/blockstack/blockstack-browser/issues/1817