### PR TITLE
Don't persist apps in redux

### DIFF
--- a/app/js/store/configure.js
+++ b/app/js/store/configure.js
@@ -10,11 +10,14 @@ const finalCreateStore = composeEnhancers(
   applyMiddleware(thunk),
   persistState(null, {
     // eslint-disable-next-line
-    slicer: paths => state => ({
-      ...state,
-      auth: AuthInitialState,
-      notifications: []
-    })
+    slicer: paths => state => {
+      const { apps, ...rest } = state // eslint-disable-line
+      return {
+        ...rest,
+        auth: AuthInitialState,
+        notifications: []
+      }
+    }
   })
 )(createStore)
 

--- a/app/js/store/reducers.js
+++ b/app/js/store/reducers.js
@@ -39,7 +39,7 @@ export function initializeStateVersion() {
  * and other state is regenerated.
  * @type {number}
  */
-export const CURRENT_VERSION: number = 18
+export const CURRENT_VERSION: number = 19
 
 const AppReducer = combineReducers({
   account: AccountReducer,


### PR DESCRIPTION
- Removes the `apps` key from redux persist
- Bump redux state version

## Testing

- `git checkout v0.35.4`
- Load the app
- `git checkout feature/dont-persist-apps`
- Refresh
- Ensure state update works, redirect to homepage works