### PR TITLE
Name registration errors and deny button

### DIFF
--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -171,24 +171,34 @@ class AuthPage extends React.Component {
     if (redirectURI) {
       // Get the current localhost authentication url that the app will redirect back to,
       // and remove the 'echo' param from it.
-      const authContinuationURI = updateQueryStringParameter(window.location.href, 'echo', '')
-      redirectURI = updateQueryStringParameter(redirectURI, 'echoReply', this.state.echoRequestId)
-      redirectURI = updateQueryStringParameter(redirectURI, 'authContinuation', encodeURIComponent(authContinuationURI))
+      const authContinuationURI = updateQueryStringParameter(
+        window.location.href,
+        'echo',
+        ''
+      )
+      redirectURI = updateQueryStringParameter(
+        redirectURI,
+        'echoReply',
+        this.state.echoRequestId
+      )
+      redirectURI = updateQueryStringParameter(
+        redirectURI,
+        'authContinuation',
+        encodeURIComponent(authContinuationURI)
+      )
     } else {
       throw new Error('Invalid redirect echo reply URI')
     }
     this.setState({ responseSent: true })
     window.location = redirectURI
   }
-  
+
   componentWillReceiveProps(nextProps) {
-
     if (!this.state.responseSent) {
-
       if (this.state.echoRequestId) {
         this.redirectUserToEchoReply()
         return
-      }  
+      }
 
       const storageConnected = this.props.api.storageConnected
       this.setState({
@@ -251,9 +261,7 @@ class AuthPage extends React.Component {
 
       if (identity.zoneFile && identity.zoneFile.length > 0) {
         const zoneFileJson = parseZoneFile(identity.zoneFile)
-        const profileUrlFromZonefile = getTokenFileUrlFromZoneFile(
-          zoneFileJson
-        )
+        const profileUrlFromZonefile = getTokenFileUrlFromZoneFile(zoneFileJson)
         if (
           profileUrlFromZonefile !== null &&
           profileUrlFromZonefile !== undefined
@@ -358,10 +366,7 @@ class AuthPage extends React.Component {
   }
 
   getFreshIdentities = async () => {
-    await this.props.refreshIdentities(
-      this.props.api,
-      this.props.addresses
-    )
+    await this.props.refreshIdentities(this.props.api, this.props.addresses)
     this.setState({ refreshingIdentities: false })
   }
 
@@ -541,7 +546,11 @@ class AuthPage extends React.Component {
   }
 
   render() {
-    const { appManifest, appManifestLoading, appManifestLoadingError } = this.props
+    const {
+      appManifest,
+      appManifestLoading,
+      appManifestLoadingError
+    } = this.props
 
     if (appManifestLoadingError) {
       return (
@@ -596,11 +605,18 @@ class AuthPage extends React.Component {
             )
           },
           deny: () => console.log('go back to app'),
+          backLabel: 'Cancel',
+          backView: () => {
+            if (document.referrer === '') {
+              window.close()
+            } else {
+              history.back()
+            }
+          },
           accounts: this.props.localIdentities,
           processing: this.state.processing,
           refreshingIdentities: this.state.refreshingIdentities,
-          selectedIndex: this.state.currentIdentityIndex,
-          disableBackOnView: 0
+          selectedIndex: this.state.currentIdentityIndex
         }
       },
       {
@@ -630,4 +646,7 @@ class AuthPage extends React.Component {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(AuthPage)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(AuthPage)

--- a/app/js/auth/views/initial.js
+++ b/app/js/auth/views/initial.js
@@ -6,7 +6,13 @@ const basicInfo = 'read your basic info'
 const readEmail = 'read your email address'
 const publishData = 'publish data stored for this app'
 
-const Accounts = ({ list, handleClick, processing, refreshingIdentities, selectedIndex }) => {
+const Accounts = ({
+  list,
+  handleClick,
+  processing,
+  refreshingIdentities,
+  selectedIndex
+}) => {
   let loadingMessage = null
   if (processing) {
     loadingMessage = 'Signing in...'
@@ -121,15 +127,6 @@ const InitialScreen = ({
           </Buttons>
         </>
       )
-    },
-    actions: {
-      items: [
-        {
-          label: 'Deny',
-          to: '/',
-          negative: true
-        }
-      ]
     }
   }
   return <ShellScreen {...rest} {...props} />

--- a/app/js/profiles/components/registration/UsernameResultDomain.js
+++ b/app/js/profiles/components/registration/UsernameResultDomain.js
@@ -36,7 +36,7 @@ const UsernameResultDomain = (props: Props) => {
       className="btn btn-primary btn-block"
       to={`/profiles/i/add-username/${index}/select/${name}`}
     >
-      Register <strong>{name}</strong> for {price} bitcoins
+      Register for {price} bitcoins
     </Link>
   )
 

--- a/app/js/profiles/components/registration/UsernameResultSubdomain.js
+++ b/app/js/profiles/components/registration/UsernameResultSubdomain.js
@@ -19,7 +19,7 @@ const UsernameResultSubdomain = (props: Props) => {
         className="btn btn-primary btn-block"
         to={`/profiles/i/add-username/${index}/select/${name}`}
       >
-        Get <strong>{name}</strong> for free
+        Register for free
       </Link>
 
     </div>

--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -286,13 +286,13 @@ const registerName = (
         }
       } catch (e) {
         logger.error('registerName: error uploading profile', e)
-        dispatch(profileUploadError(e))
+        dispatch(profileUploadError(e.message))
         throw e
       }
     }
   } catch (e) {
     logger.error('registerName: error', e)
-    dispatch(registrationError(e))
+    dispatch(registrationError(e.message))
   }
 }
 

--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -1,19 +1,23 @@
 import * as types from './types'
-import { makeProfileZoneFile, transactions, config, network, safety } from 'blockstack'
+import {
+  makeProfileZoneFile,
+  transactions,
+  config,
+  network,
+  safety
+} from 'blockstack'
 import { uploadProfile } from '../../../account/utils'
 import { IdentityActions } from '../identity'
 import { signProfileForUpload, authorizationHeaderValue } from '@utils'
 import { DEFAULT_PROFILE } from '@utils/profile-utils'
 import { isSubdomain, getNameSuffix } from '@utils/name-utils'
+import { notify } from 'reapop'
 import log4js from 'log4js'
 
 const logger = log4js.getLogger(__filename)
 
-
-function profileUploading() {
-  return {
-    type: types.PROFILE_UPLOADING
-  }
+const profileUploading = {
+  type: types.PROFILE_UPLOADING
 }
 
 function profileUploadError(error) {
@@ -55,10 +59,19 @@ function beforeRegister() {
   }
 }
 
-function registerSubdomain(api, domainName, identityIndex, ownerAddress, zoneFile) {
+async function registerSubdomain(
+  api,
+  domainName,
+  identityIndex,
+  ownerAddress,
+  zoneFile
+) {
   let nameSuffix = null
+
   nameSuffix = getNameSuffix(domainName)
+
   logger.debug(`registerName: ${domainName} is a subdomain of ${nameSuffix}`)
+
   const registerUrl = api.subdomains[nameSuffix].registerUrl
 
   const registrationRequestBody = JSON.stringify({
@@ -75,24 +88,41 @@ function registerSubdomain(api, domainName, identityIndex, ownerAddress, zoneFil
 
   logger.info(`Submitting registration for ${domainName} to ${registerUrl}`)
 
-  return fetch(registerUrl, {
+  const response = await fetch(registerUrl, {
     method: 'POST',
     headers: requestHeaders,
     body: registrationRequestBody
   })
-  .then((response) => {
-    if (!response.ok) {
-      logger.error(`Subdomain registrar responded with status code ${response.status}`)
-      return Promise.reject(new Error('Failed to register username'))
-    }
-    return response.text()
-  })
-  .then((responseText) => JSON.parse(responseText))
+
+  if (!response.ok) {
+    logger.error(
+      `Subdomain registrar responded with status code ${response.status}`
+    )
+
+    return Promise.reject({
+      error: 'Failed to register username',
+      status: response.status
+    })
+  }
+
+  const responseText = await response.text()
+
+  return JSON.parse(responseText)
 }
 
-function registerDomain(myNet, tx, domainName, identityIndex, ownerAddress, paymentKey, zoneFile) {
+function registerDomain(
+  myNet,
+  tx,
+  domainName,
+  identityIndex,
+  ownerAddress,
+  paymentKey,
+  zoneFile
+) {
   if (!paymentKey) {
-    logger.error('registerName: payment key not provided for non-subdomain registration')
+    logger.error(
+      'registerName: payment key not provided for non-subdomain registration'
+    )
     return Promise.reject('Missing payment key')
   }
 
@@ -102,31 +132,33 @@ function registerDomain(myNet, tx, domainName, identityIndex, ownerAddress, paym
   let preorderTx = ''
   let registerTx = ''
 
-  return safety.addressCanReceiveName(ownerAddress)
-    .then((canReceive) => {
+  return safety
+    .addressCanReceiveName(ownerAddress)
+    .then(canReceive => {
       if (!canReceive) {
         return Promise.reject(`Address ${ownerAddress} cannot receive names.`)
       }
       return safety.isNameValid(domainName)
     })
-    .then((nameValid) => {
+    .then(nameValid => {
       if (!nameValid) {
         return Promise.reject(`Name ${domainName} is not valid`)
       }
       return true
     })
     .then(() => tx.makePreorder(domainName, coercedAddress, compressedKey))
-    .then((rawtx) => {
+    .then(rawtx => {
       preorderTx = rawtx
       return rawtx
     })
-    .then((rawtx) => {
+    .then(rawtx => {
       myNet.modifyUTXOSetFrom(preorderTx)
       return rawtx
     })
     .then(() =>
-      tx.makeRegister(domainName, coercedAddress, compressedKey, zoneFile))
-    .then((rawtx) => {
+      tx.makeRegister(domainName, coercedAddress, compressedKey, zoneFile)
+    )
+    .then(rawtx => {
       registerTx = rawtx
       return rawtx
     })
@@ -136,84 +168,131 @@ function registerDomain(myNet, tx, domainName, identityIndex, ownerAddress, paym
     })
     .then(() => {
       logger.debug(
-        `Sending registration to transaction broadcaster at ${myNet.broadcastServiceUrl}`)
+        `Sending registration to transaction broadcaster at ${
+          myNet.broadcastServiceUrl
+        }`
+      )
       return myNet.broadcastNameRegistration(preorderTx, registerTx, zoneFile)
     })
 }
 
-function registerName(api, domainName, identity, identityIndex,
-                      ownerAddress, keypair, paymentKey = null) {
+const registerName = (
+  api,
+  domainName,
+  identity,
+  identityIndex,
+  ownerAddress,
+  keypair,
+  paymentKey = null
+) => async dispatch => {
   logger.info(`registerName: domainName: ${domainName}`)
-  return dispatch => {
-    logger.debug(`Signing a new profile for ${domainName}`)
-    const profile = identity.profile || DEFAULT_PROFILE
-    const signedProfileTokenData = signProfileForUpload(profile, keypair, api)
+  logger.debug(`Signing a new profile for ${domainName}`)
 
-    dispatch(profileUploading())
-    logger.info(`Uploading ${domainName} profile...`)
-    return uploadProfile(api, identity, keypair, signedProfileTokenData)
-    .then((profileUrl) => {
-      logger.info(`Uploading ${domainName} profiled succeeded.`)
-      const tokenFileUrl = profileUrl
-      logger.debug(`tokenFileUrl: ${tokenFileUrl}`)
+  const profile = identity.profile || DEFAULT_PROFILE
+  const signedProfileTokenData = signProfileForUpload(profile, keypair, api)
+  dispatch(profileUploading)
+  logger.info(`Uploading ${domainName} profile...`)
+  try {
+    const profileUrl = await uploadProfile(
+      api,
+      identity,
+      keypair,
+      signedProfileTokenData
+    )
+    logger.info(`Uploading ${domainName} profiled succeeded.`)
+    const tokenFileUrl = profileUrl
+    logger.debug(`tokenFileUrl: ${tokenFileUrl}`)
+    logger.info('Making profile zonefile...')
+    const zoneFile = makeProfileZoneFile(domainName, tokenFileUrl)
+    const nameIsSubdomain = isSubdomain(domainName)
+    dispatch(registrationSubmitting())
+    if (nameIsSubdomain) {
+      try {
+        const res = await registerSubdomain(
+          api,
+          domainName,
+          identityIndex,
+          ownerAddress,
+          zoneFile
+        )
 
-      logger.info('Making profile zonefile...')
-      const zoneFile = makeProfileZoneFile(domainName, tokenFileUrl)
-
-      const nameIsSubdomain = isSubdomain(domainName)
-
-      dispatch(registrationSubmitting())
-
-      if (nameIsSubdomain) {
-        return registerSubdomain(api, domainName, identityIndex, ownerAddress, zoneFile)
-          .then((responseJson) => {
-            if (responseJson.error) {
-              logger.error(responseJson.error)
-              dispatch(registrationError(responseJson.error))
-            } else {
-              logger.debug(`Successfully submitted registration for ${domainName}`)
-              dispatch(registrationSubmitted())
-              dispatch(IdentityActions.addUsername(identityIndex, domainName))
-            }
-          })
-          .catch((error) => {
-            logger.error('registerName: error POSTing registration to registrar', error)
-            dispatch(registrationError(error))
-            throw error
-          })
-      } else {
-        if (api.regTestMode) {
-          logger.info('Using regtest network')
-          config.network = network.defaults.LOCAL_REGTEST
-          // browser regtest environment uses 6270
-          config.network.blockstackAPIUrl = 'http://localhost:6270'
+        if (res.error) {
+          logger.error(res.error)
+          let message =
+            `Sorry, something went wrong while registering ${domainName}. ` +
+            'You can try to register again later from your profile page. Some ' +
+            'apps may be unusable until you do.'
+          if (res.status === 409) {
+            message =
+              "Sorry, it looks like we weren't able to process your name registration. Please contact us at support@blockstack.org for help. Some apps may be unusable until you register an ID."
+          }
+          dispatch(registrationError(message))
+          dispatch(
+            notify({
+              title: 'Username Registration Failed',
+              message,
+              status: 'error',
+              dismissAfter: 6000,
+              dismissible: true,
+              closeButton: true,
+              position: 'b'
+            })
+          )
+        } else {
+          logger.debug(`Successfully submitted registration for ${domainName}`)
+          dispatch(registrationSubmitted())
+          dispatch(IdentityActions.addUsername(identityIndex, domainName))
         }
-
-        const myNet = config.network
-
-        return registerDomain(myNet, transactions, domainName, identityIndex,
-          ownerAddress, paymentKey, zoneFile)
-          .then((response) => {
-            if (response.status) {
-              logger.debug(`Successfully submitted registration for ${domainName}`)
-              dispatch(registrationSubmitted())
-              dispatch(IdentityActions.addUsername(identityIndex, domainName))
-            } else {
-              logger.error(response)
-              dispatch(registrationError(response))
-            }
-          })
-          .catch(error => {
-            logger.error('registerName: error submitting name registration', error)
-            dispatch(registrationError(error))
-            throw new Error('Error submitting name registration')
-          })
+      } catch (e) {
+        logger.error('registerName: error POSTing registration to registrar', e)
+        let message =
+          `Sorry, something went wrong while registering ${domainName}. ` +
+          'You can try to register again later from your profile page. Some ' +
+          'apps may be unusable until you do.'
+        if (e.status === 409) {
+          message =
+            "Sorry, it looks like we weren't able to process your name registration. Please contact us at support@blockstack.org for help. Some apps may be unusable until you register an ID."
+        }
+        dispatch(registrationError(message))
+        throw new Error(message)
       }
-    }).catch((error) => {
-      logger.error('registerName: error uploading profile', error)
-      dispatch(profileUploadError(error))
-      throw error
-    })
+    } else {
+      // paid name
+      if (api.regTestMode) {
+        logger.info('Using regtest network')
+        config.network = network.defaults.LOCAL_REGTEST
+        // browser regtest environment uses 6270
+        config.network.blockstackAPIUrl = 'http://localhost:6270'
+      }
+      const myNet = config.network
+
+      try {
+        const response = await registerDomain(
+          myNet,
+          transactions,
+          domainName,
+          identityIndex,
+          ownerAddress,
+          paymentKey,
+          zoneFile
+        )
+        if (response.status && response.status !== 409) {
+          logger.debug(`Successfully submitted registration for ${domainName}`)
+          dispatch(registrationSubmitted())
+          dispatch(IdentityActions.addUsername(identityIndex, domainName))
+        } else {
+          logger.error(response)
+          dispatch(registrationError(response))
+        }
+      } catch (e) {
+        logger.error('registerName: error uploading profile', e)
+        dispatch(profileUploadError(e))
+        throw e
+      }
+    }
+  } catch (e) {
+    logger.error('registerName: error', e)
+    dispatch(registrationError(e))
   }
 }
 

--- a/app/js/profiles/store/registration/actions.js
+++ b/app/js/profiles/store/registration/actions.js
@@ -16,9 +16,9 @@ import log4js from 'log4js'
 
 const logger = log4js.getLogger(__filename)
 
-const profileUploading = {
+const profileUploading = () => ({
   type: types.PROFILE_UPLOADING
-}
+})
 
 function profileUploadError(error) {
   return {
@@ -190,7 +190,7 @@ const registerName = (
 
   const profile = identity.profile || DEFAULT_PROFILE
   const signedProfileTokenData = signProfileForUpload(profile, keypair, api)
-  dispatch(profileUploading)
+  dispatch(profileUploading())
   logger.info(`Uploading ${domainName} profile...`)
   try {
     const profileUrl = await uploadProfile(

--- a/app/js/profiles/store/registration/reducer.js
+++ b/app/js/profiles/store/registration/reducer.js
@@ -1,11 +1,16 @@
 import * as types from './types'
+import { CHECKING_NAME_AVAILABILITY } from '../availability/types'
 
-const initialState = {
-
-}
+const initialState = {}
 
 function RegistrationReducer(state = initialState, action) {
   switch (action.type) {
+    // reset error on new name search
+    case CHECKING_NAME_AVAILABILITY:
+      return {
+        ...state,
+        error: null
+      }
     case types.REGISTRATION_BEFORE_SUBMIT:
       return Object.assign({}, state, {
         profileUploading: false,
@@ -18,6 +23,7 @@ function RegistrationReducer(state = initialState, action) {
       return Object.assign({}, state, {
         profileUploading: false,
         registrationSubmitting: true,
+        registrationSubmitted: false,
         error: null,
         preventRegistration: true
       })
@@ -33,7 +39,8 @@ function RegistrationReducer(state = initialState, action) {
       return Object.assign({}, state, {
         registrationSubmitting: false,
         error: action.error,
-        preventRegistration: false
+        preventRegistration: false,
+        registrationSubmitted: false
       })
     case types.PROFILE_UPLOADING:
       return Object.assign({}, state, {

--- a/test/profiles/store/registration/reducer.test.js
+++ b/test/profiles/store/registration/reducer.test.js
@@ -1,16 +1,13 @@
 import {
-  RegistrationActions, RegistrationReducer
+  RegistrationActions,
+  RegistrationReducer
 } from '../../../../app/js/profiles/store/registration'
 
-const initialState = {
-
-}
+const initialState = {}
 
 describe('Registration Store: RegistrationReducer', () => {
   it('should return the proper initial state', () => {
-    assert.deepEqual(
-      RegistrationReducer(undefined, {}),
-      initialState)
+    assert.deepEqual(RegistrationReducer(undefined, {}), initialState)
   })
 
   describe('Registration Store: RegistrationReducer: successful registration', () => {
@@ -32,7 +29,8 @@ describe('Registration Store: RegistrationReducer', () => {
         preventRegistration: true,
         error: null,
         profileUploading: false,
-        registrationSubmitting: true
+        registrationSubmitting: true,
+        registrationSubmitted: false
       }
       const action = RegistrationActions.registrationSubmitting()
       actualState = RegistrationReducer(actualState, action)
@@ -98,7 +96,8 @@ describe('Registration Store: RegistrationReducer', () => {
         preventRegistration: true,
         error: null,
         profileUploading: false,
-        registrationSubmitting: true
+        registrationSubmitting: true,
+        registrationSubmitted: false
       }
       const action = RegistrationActions.registrationSubmitting()
       actualState = RegistrationReducer(actualState, action)
@@ -110,7 +109,8 @@ describe('Registration Store: RegistrationReducer', () => {
         preventRegistration: false,
         error: 'Core error',
         profileUploading: false,
-        registrationSubmitting: false
+        registrationSubmitting: false,
+        registrationSubmitted: false
       }
       const action = RegistrationActions.registrationError('Core error')
       actualState = RegistrationReducer(actualState, action)


### PR DESCRIPTION
### What this does
This PR fixes two main issues:

## Fix id.blockstack name registration https://github.com/blockstack/blockstack-browser/issues/1764
- create id / sign in here -> https://deploy-preview-1898--reporter-beaver-73821.netlify.com
- go to IDs page
- hit 'more'
- generate a new ID
- hit 'add username' 
- search for a free subdomain
- when you are on the page that asks if you'd like to register for free, [**block requests to registrar.blockstack.org**](https://developers.google.com/web/updates/2017/04/devtools-release-notes#block-requests)
- attempt to register the subdomain
- you will see a failure message (this message will not display a support email, however if the server responds with 409, it will show `support@blockstack.org`).
## Reduce misuse of "Deny" button during onboarding https://github.com/blockstack/blockstack-browser/issues/1816
- how to test same tab example:
  - Login / create an account here -> https://deploy-preview-1898--reporter-beaver-73821.netlify.com
  - use this app to sign in https://react-blockstack-redux-bundler-yjnojbyuwr.now.sh/sign-in
  - notice that the 'Cancel' button is in the top right
  - hit the cancel button
- how to test native browser version:
  - clone this repo and checkout this PR `feature/better-errors-notifications`
  - `yarn && yarn dev`
  - set dev mode on the blockstack browser app (opt click icon in nav bar)
  - auth with any blockstack app
  - hit cancel in auth modal
  - window should close

For mobile apps, I've opted to hide the cancel button in general as per @yknl's suggestion.