### PR TITLE
Handle relative icon urls in manifest

### DIFF
--- a/app/js/components/ui/containers/headers.js
+++ b/app/js/components/ui/containers/headers.js
@@ -64,6 +64,10 @@ const Header = ({
 }) => {
   const renderBugs = () => {
     if (app) {
+      const appIcon = app.manifestURI
+        ? new URL(app.icon, app.manifestURI).toString()
+        : app.icon
+
       return (
         <Bugs>
           <BlockstackBug invert={invert} size={28} />
@@ -71,7 +75,7 @@ const Header = ({
             <ChevronDoubleRightIcon color={'rgba(39, 16, 51, 0.2)'} size={18} />
           </StyledBug.Arrows>
           <Bug size={28} title={app.name}>
-            <img src={app.icon} alt={app.name} />
+            <img src={appIcon} alt={app.name} />
           </Bug>
         </Bugs>
       )


### PR DESCRIPTION
This is the same code from @friedger in #1875 , but is built on top of the latest `develop`, which includes the latest blockstack.js stable. I made a new branch because I can't push to Friedger's fork.