### PR TITLE
Upgrade blockstack.js to 19.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bip39": "^2.2.0",
     "bitcoinjs-lib": "^3.2.0",
     "blockstack-ui": "^0.0.71",
-    "blockstack": "^19.1.0",
+    "blockstack": "^19.2.1",
     "body-parser": "^1.16.1",
     "bootstrap": "^4.0.0-beta",
     "browser-stdout": "^1.3.0",


### PR DESCRIPTION
This PR
* upgrades blockstack.js to finally fix #1922 