### PR TITLE
Allow collection scopes as valid during auth

### DIFF
--- a/app/js/auth/utils.js
+++ b/app/js/auth/utils.js
@@ -36,13 +36,12 @@ export function validateScopes(scopes: Array<string>): boolean {
     return true
   }
 
-  let valid = false
+  let valid = true
   for (let i = 0; i < scopes.length; i++) {
     const scope = scopes[i]
-    if (VALID_SCOPES[scope] === true) {
-      valid = true
-    } else {
-      return false
+    const isCollectionScope = scope.indexOf('collection.') === 0
+    if (!isCollectionScope && VALID_SCOPES[scope] !== true) {
+      valid = false
     }
   }
   return valid

--- a/test/auth/utils.js
+++ b/test/auth/utils.js
@@ -16,7 +16,7 @@ describe('auth-utils', () => {
     })
 
     it('should return false for a scope not on whitelist array', () => {
-      const scopes = ['illegal_scope']
+      const scopes = ['illegal_scope', 'store_write']
       assert(!validateScopes(scopes))
     })
 
@@ -31,6 +31,11 @@ describe('auth-utils', () => {
       assert(validateScopes(scopes))
 
       scopes = ['email', 'store_write']
+      assert(validateScopes(scopes))
+    })
+
+    it('should allow colleciton scopes', () => {
+      const scopes = ['store_write', 'collection.contact']
       assert(validateScopes(scopes))
     })
   })


### PR DESCRIPTION
As described in #1969 , if you pass a collection scope, the current production browser will block the authentication request because it has an invalid scope. I've changed that to allow collection scopes.

I also fixed a bug where the `validateScopes` function only returned `false` if the last scope was invalid - if you passed scopes like `['invalid', 'store_write']` then the function would pass.

You can test this with https://planet.friedger.de/ , which requests the 'contacts' scope.