### PR TITLE
Remove github social proof

### DIFF
--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -35,10 +35,10 @@ import { defaultAvatarImage } from '@components/ui/common/constants'
 const logger = log4js.getLogger(__filename)
 
 const accountTypes = [
-  'twitter',
-  'facebook',
   'bitcoin',
-  'instagram'
+  'facebook',
+  'instagram',
+  'twitter'
 ]
 
 const hiddenAccountTypes = ['linkedIn', 'instagram']

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -37,7 +37,6 @@ const logger = log4js.getLogger(__filename)
 const accountTypes = [
   'twitter',
   'facebook',
-  'github',
   'bitcoin',
   'instagram'
 ]
@@ -244,8 +243,6 @@ export class DefaultProfilePage extends Component {
       verificationUrl = `https://twitter.com/intent/tweet?text=${verificationText}`
     } else if (service === 'facebook') {
       verificationUrl = `https://www.facebook.com/dialog/feed?app_id=258121411364320&link=${url}`
-    } else if (service === 'github') {
-      verificationUrl = 'https://gist.github.com/'
     } else if (service === 'instagram') {
       // no op
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blockstack-browser",
   "description": "The Blockstack browser",
-  "version": "0.36.4",
+  "version": "0.36.5",
   "author": "Blockstack PBC <admin@blockstack.com>",
   "dependencies": {
     "bigi": "^1.4.2",

--- a/test/profiles/DefaultProfilePage.test.js
+++ b/test/profiles/DefaultProfilePage.test.js
@@ -38,7 +38,7 @@ function setup(accounts = []) {
 }
 
 function alphabeticalOrdered(accounts) {
-  return accounts.first().props().service <
+  return accounts.first().props().service <=
     accounts.last().props().service
 }
 


### PR DESCRIPTION
This hotfix removes the Github gist social proof option from the profile editor.