### PR TITLE
Add appsMeta with pubKey to profile (for storageConnected apps)

### DIFF
--- a/app/js/auth/index.js
+++ b/app/js/auth/index.js
@@ -319,6 +319,11 @@ class AuthPage extends React.Component {
             apps = profile.apps
           }
 
+          let appsMeta = {}
+          if (profile.hasOwnProperty('appsMeta')) {
+            appsMeta = profile.appsMeta
+          }
+
           if (storageConnected) {
             const hubUrl = this.props.api.gaiaHubUrl
             getAppBucketUrl(hubUrl, appPrivateKey)
@@ -327,12 +332,18 @@ class AuthPage extends React.Component {
                   `componentWillReceiveProps: appBucketUrl ${appBucketUrl}`
                 )
                 apps[appDomain] = appBucketUrl
+                if (appsMeta.hasOwnProperty(appDomain)) {
+                  appsMeta[appDomain] = { ...appsMeta[appDomain], publicKey: getPublicKeyFromPrivate(appPrivateKey) }
+                } else {
+                  appsMeta[appDomain] = { publicKey: getPublicKeyFromPrivate(appPrivateKey) }
+                }
                 logger.debug(
                   `componentWillReceiveProps: new apps array ${JSON.stringify(
                     apps
                   )}`
                 )
                 profile.apps = apps
+                profile.appsMeta = appsMeta
                 const signedProfileTokenData = signProfileForUpload(
                   profile,
                   nextProps.identityKeypairs[identityIndex],


### PR DESCRIPTION
This PR
* add `appsMeta` to the user profile (next to `apps`) that contains the public key for the user for the app.

Required for https://github.com/blockstack/blockstack.js/issues/458