### PR TITLE
Deprecations for Stacks 2.0

### DIFF
--- a/app/js/components/Navbar.js
+++ b/app/js/components/Navbar.js
@@ -100,7 +100,7 @@ const Navbar = withRouter(({ location }) => (
     borderBottom="1px solid #f0f0f0"
     bg="white"
     position="fixed"
-    top={0}
+    top="50px"
     width={1}
     zIndex={999}
   >

--- a/app/js/components/ui/containers/AppHomeWrapper.js
+++ b/app/js/components/ui/containers/AppHomeWrapper.js
@@ -22,7 +22,7 @@ const StyledAppHomeWrapper = styled.div.attrs({
     }
   }
   .home-screen {
-    padding-top: 100px;
+    padding-top: 135px;
   }
   * {
     pointer-events: none !important;

--- a/app/js/profiles/DefaultProfilePage.js
+++ b/app/js/profiles/DefaultProfilePage.js
@@ -785,7 +785,7 @@ export class DefaultProfilePage extends Component {
                           </span>
                         </div>
 
-                        <div className="text-center">
+                        {/* <div className="text-center">
                           {identity.canAddUsername ? (
                             <div className="text-center">
                               <Link
@@ -807,7 +807,7 @@ export class DefaultProfilePage extends Component {
                               ) : null}
                             </div>
                           )}
-                        </div>
+                        </div> */}
 
                         <div
                           className="pro-card-identity-address m-b-25 text-center

--- a/app/js/profiles/components/IdentityItem.js
+++ b/app/js/profiles/components/IdentityItem.js
@@ -102,20 +102,7 @@ export class IdentityItem extends Component {
                 <p className="card-title">
                   {this.props.canAddUsername ? (
                     <div>
-                      <a
-                        href="#"
-                        onClick={event => {
-                          event.preventDefault()
-                          event.stopPropagation()
-                          this.props.router.push(
-                            `/profiles/i/add-username/${
-                              this.props.index
-                            }/search`
-                          )
-                        }}
-                      >
-                        Add username
-                      </a>
+                      Account {this.props.index}
                     </div>
                   ) : (
                     <>

--- a/app/js/sign-up/index.js
+++ b/app/js/sign-up/index.js
@@ -618,7 +618,7 @@ class Onboarding extends React.Component {
       {
         show: VIEWS.INITIAL,
         props: {
-          next: () => this.updateView(VIEWS.USERNAME)
+          next: () => this.updateView(VIEWS.PASSWORD)
         }
       },
       {

--- a/app/js/wallet/ReceivePage.js
+++ b/app/js/wallet/ReceivePage.js
@@ -41,11 +41,6 @@ class ReceivePage extends Component {
         <Balance />
         {address ?
           <div>
-            <div className="qrcode-wallet">
-              <QRCode
-                value={address}
-              />
-            </div>
             <div className="highlight-wallet text-center">
               <pre>
                 <code>{address}</code>

--- a/app/js/wallet/WalletApp.js
+++ b/app/js/wallet/WalletApp.js
@@ -35,7 +35,7 @@ class WalletApp extends Component {
       <div>
         <Navbar activeTab="wallet" />
         <div className="container-fluid col-centered form-container-secondary" style={{ padding: '20px 15px' }}>
-          <strong>NOTE:</strong> You cannot use this wallet to send and receive Stacks (STX) tokens. Also, you cannot use the Bitcoin (BTC) address on this page to fund STX transactions. This wallet and its address <strong>only</strong> support the purchase of Blockstack identities (IDs). <strong>To create or fund STX transactions, use the Stacks Wallet software.</strong> See <a href="https://docs.blockstack.org/org/wallet-install.html" target="_blank">the Stacks Wallet software documentation</a> for more information. 
+          <strong>NOTE:</strong> You cannot use this wallet to send and receive Stacks (STX) tokens. Also, you cannot use the Bitcoin (BTC) address on this page to fund STX transactions. This wallet and its address <strong>only</strong> support the purchase of Blockstack identities (IDs). <strong>To create or fund STX transactions, use the Stacks Wallet software.</strong>
         </div>
         <div className="container-fluid col-centered form-container-secondary" style={{ padding: '20px 15px' }}>
           <strong>This product is deprecated.</strong> We advise you to withdraw any BTC from this wallet. 

--- a/app/js/wallet/WalletApp.js
+++ b/app/js/wallet/WalletApp.js
@@ -34,12 +34,13 @@ class WalletApp extends Component {
     return (
       <div>
         <Navbar activeTab="wallet" />
-        <div className="container-fluid col-centered form-container-secondary">
+        <div className="container-fluid col-centered form-container-secondary" style={{ padding: '20px 15px' }}>
           <strong>NOTE:</strong> You cannot use this wallet to send and receive Stacks (STX) tokens. Also, you cannot use the Bitcoin (BTC) address on this page to fund STX transactions. This wallet and its address <strong>only</strong> support the purchase of Blockstack identities (IDs). <strong>To create or fund STX transactions, use the Stacks Wallet software.</strong> See <a href="https://docs.blockstack.org/org/wallet-install.html" target="_blank">the Stacks Wallet software documentation</a> for more information. 
         </div>
+        <div className="container-fluid col-centered form-container-secondary" style={{ padding: '20px 15px' }}>
+          <strong>This product is deprecated.</strong> We advise you to withdraw any BTC from this wallet. 
+        </div>
         <SecondaryNavBar
-          leftButtonTitle="Receive"
-          leftButtonLink="/wallet/receive"
           isLeftActive={(activeTabUrl === '/wallet/receive')}
           rightButtonTitle="Send"
           rightButtonLink="/wallet/send"

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -28,6 +28,11 @@
     </style>
 </head>
 <body>
+<div id="deprecation-banner">
+  <a href="https://blockstack.org/wallet">
+    Deprecated: Please switch to the Stacks Wallet or upgrade your app to Stacks.js
+  </a>
+</div>
 <div id="loader">
     <svg width="29" height="28" viewBox="0 0 29 28" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd"

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -4,7 +4,7 @@
 .body-main {
     width: 100%;
     height: 100%;
-    padding-top: 100px;
+    padding-top: 135px;
 }
 .body-main.no-header {
   padding-top: 0;
@@ -2581,4 +2581,18 @@ a.modal-body {
         width: 90%;
         margin-top: 12%;
     }
+}
+
+#deprecation-banner {
+    position: fixed;
+    z-index: 999;
+    background-color: rgb(240, 213, 96);
+    width: 100%;
+    padding: 15px 0;
+    text-align: center;
+}
+
+#deprecation-banner a {
+    color: black;
+    font-weight: 600;
 }

--- a/test-e2e/auth/create-account.js
+++ b/test-e2e/auth/create-account.js
@@ -24,13 +24,13 @@ createTestSuites('account-creation', ({driver, browserHostUrl}) => {
     await driver.click(By.xpath('//div[text()="Create new ID"]'));
   });
 
-  let randomUsername
-  step('enter unique username', async () => {
-    randomUsername = `test_e2e_${Date.now() / 100000 | 0}_${helpers.getRandomInt(100000, 999999)}`;
-    await driver.setText(By.css('input[type="text"][name="username"]'), randomUsername);
-    await driver.click(By.xpath('//button[contains(., "Check Availability")]'));
-    await driver.click(By.xpath('//button[contains(., "Continue")]'));
-  });
+  let randomUsername = 'notreal';
+  // step('enter unique username', async () => {
+  //   randomUsername = `test_e2e_${Date.now() / 100000 | 0}_${helpers.getRandomInt(100000, 999999)}`;
+  //   await driver.setText(By.css('input[type="text"][name="username"]'), randomUsername);
+  //   await driver.click(By.xpath('//button[contains(., "Check Availability")]'));
+  //   await driver.click(By.xpath('//button[contains(., "Continue")]'));
+  // });
 
   step('enter password', async () => {
     const randomPassword = helpers.getRandomString();


### PR DESCRIPTION
This PR closes #2005 and #2068.

Given that we will not have a working registrar at launch, I've also removed the ability to register a username from within the app.

- Removed any 'Add username' stuff when logged in
- Skip the 'username' step when signing up
- Removed the QR code on the receive page
- Removed the "Receive" button on wallet page
- Add deprecation banner
  - The banner links to https://blockstack.org/wallet, since that works right now, and will be redirected in DNS soon.
- Add deprecation notice on wallet page

![image](https://user-images.githubusercontent.com/1109058/104113698-d9feac80-52b0-11eb-9c13-01bb09fc8a72.png)
