### PR TITLE
docs: removing the unnecessary $ from terminal commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ and stop any running Blockstack applications (blockstack-browser or blockstack
 api) then:
 
 ```
-$ docker-compose up -d
+docker-compose up -d
 ```
 
 This brings up


### PR DESCRIPTION
Removing the unnecessary $ from terminal commands.

Referring to: https://github.com/blockstack/docs/issues/1190 